### PR TITLE
fix: table references not working

### DIFF
--- a/template/chapters/advanced_elements.typ
+++ b/template/chapters/advanced_elements.typ
@@ -20,7 +20,7 @@ Inserting figures and code blocks into your Typst document enhances its informat
 
 === Tables
 
-Similar to images you can insert table figures. See more table examples and more advanced usage in @appendix-table-examples
+Similar to images you can insert table figures. See more table examples and more advanced usage in @appendix-table-examples.
 
 #typst-preview(
   "Table Figures in Typst",

--- a/template/utils.typ
+++ b/template/utils.typ
@@ -86,14 +86,16 @@
       it.body
     })
   }
-  figure(
-    body,
-    caption: caption,
-    kind: table,
-  )
-  if reference != none {
-    label(reference)
-  }
+  [
+    #figure(
+      body,
+      caption: caption,
+      kind: table,
+    )
+    #if reference != none {
+      label(reference)
+    }
+  ]
 }
 
 #let styled-table(


### PR DESCRIPTION
Unfortunately my code for table figures contains a bug where using the `reference` parameter in `tablefigure-raw` is not applied correctly, leading to compilation errors.

This PR fixes this by copying the labeling approach of `codefigure`.