### PR TITLE
chore: Add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,13 @@
+# Global owners
+* @dhbw-typst/core
+
+# Adapters
+## DHBW Karlsruhe
+template/template/dhbw-ka.typ @dhbw-typst/dhbw-ka
+template/main-dhbw-ka.typ @dhbw-typst/dhbw-ka
+
+## DHBW Mannheim
+## - Currently no maintainer -
+
+## IHK
+## - Currently no maintainer -


### PR DESCRIPTION
Added two teams: @dhbw-typst/core and @dhbw-typst/dhbw-ka
Added the "require review by codeowners" check
Added those teams as codeowners

We are missing codeowners for DHBW Mannheim and IHK

closes #8