### PR TITLE
chore: Add documentation build to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,18 +93,26 @@ jobs:
           for file in $(ls template/main-*.typ); do
             ./typst compile $file
           done
+      - name: Build documentation
+        if: steps.version.outputs.hasNextVersion == 'true'
+        run: |
+          ./typst compile documentation.typ --input version=${{ steps.version.outputs.version }}
       - name: Release dev repo
         if: steps.version.outputs.hasNextVersion == 'true'
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           token: ${{ secrets.BOT_PAT }}
-          files: template/main-*.pdf
+          files: |
+            template/main-*.pdf
+            documentation.pdf
           tag_name: ${{ steps.version.outputs.version }}
       - name: Release prod repo
         if: steps.version.outputs.hasNextVersion == 'true'
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           token: ${{ secrets.BOT_PAT }}
-          files: template/main-*.pdf
+          files: |
+            template/main-*.pdf
+            documentation.pdf
           tag_name: ${{ steps.version.outputs.version }}
           repository: dhbw-typst/oderso-template


### PR DESCRIPTION
Documentation building and releasing was removed by accident.

This PR adds the documentation again. I'll manually add the documentation build to the latest release.