### PR TITLE
chore: README nitpicks

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -10,7 +10,7 @@ The template was built for DHBW Karlsruhe, but also has adapters for DHBW Mannhe
 > [!TIP]
 > Want to see how the template looks? Download a preview PDF for [DHBW Karlsruhe](https://github.com/dhbw-typst/oderso-template/releases/latest/download/main-dhbw-ka.pdf), [DHBW Mannheim](https://github.com/dhbw-typst/oderso-template/releases/latest/download/main-dhbw-ma.pdf) or [IHK](https://github.com/dhbw-typst/oderso-template/releases/latest/download/main-ihk.pdf) to inspect the final result.
 >
-> Those pdfs also contain **a detailed documentation of the template**.
+> A description of all functions and properties can be found in the [package documentation]((https://github.com/dhbw-typst/oderso-template/releases/latest/download/documentation.pdf)).
 
 ## 🏃‍♂️ Getting Started
 
@@ -80,5 +80,5 @@ Over the years, the template has grown to include many features and now supports
 
 The goal of this template is to make writing your thesis at DHBW as easy as possible! That said, there are some alternatives worth knowing about:
 
-- [clean-dhbw](https://typst.app/universe/package/clean-dhbw/): A template written by a professor of the DHBW Karlsruhe. We found it to be fairly opinionated and limited in customization. At also lacks many features this template provides.
-- [supercharged-dhbw](https://github.com/DannySeidel/typst-dhbw-template): Another template for DHBW students. As of 16.07.2025, the last commit was over half a year old, so outdated package versions may cause issues with the latest version of Typst. We do not recommend using an unmaintained template, especially for users less familiar with Typst.
+- [clean-dhbw](https://typst.app/universe/package/clean-dhbw/): A template written by a professor of the DHBW Karlsruhe. We found it to be fairly opinionated and limited in customization. It also lacks many features this template provides.
+- [supercharged-dhbw](https://typst.app/universe/package/supercharged-dhbw/): Another template for DHBW Karlsruhe students. As of May 2026, the last commit was over a year old, so outdated package versions may cause issues with the latest version of Typst. We do not recommend using an unmaintained template, especially for users less familiar with Typst.


### PR DESCRIPTION
- Removed wrong statement about detailed documentation and link to compiled documentation
- Updated link to supercharged dhbw to point to typst universe and updated deprecation warning
- Fixed a small typo text about clean-dhbw