### PR TITLE
chore: fix diff pipeline

### DIFF
--- a/.github/workflows/codeAnalysis.yml
+++ b/.github/workflows/codeAnalysis.yml
@@ -137,6 +137,7 @@ jobs:
         with:
           pattern: diff-*
           path: diffs
+          merge-multiple: true
       - name: Build comment body
         id: build_comment
         run: |
@@ -148,6 +149,10 @@ jobs:
           BODY="${BODY}\n>"
 
           for diff in diffs/diff-*; do
+            if [[ ! -f "$diff" ]]; then
+              continue
+            fi
+
             file_name=$(basename "$diff" | sed 's/^diff-//')
             echo "Found diff for ${file_name}"
             BODY="${BODY}\n> - \`${file_name}\` — download [\`diff-${file_name}\`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"

--- a/.github/workflows/codeAnalysis.yml
+++ b/.github/workflows/codeAnalysis.yml
@@ -1,8 +1,6 @@
 name: Code Analysis
 on:
   pull_request:
-    branches:
-      - main
   workflow_dispatch:
 jobs:
   discover_files:
@@ -100,10 +98,10 @@ jobs:
       - name: Build PDF on PR branch
         run: |
           ./typst compile new/${{ matrix.path }} new.pdf
-      - name: Checkout main branch
+      - name: Checkout base branch
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: main
+          ref: ${{ github.base_ref || 'main' }}
           path: old
       - name: Build PDF on main branch
         run: |
@@ -124,15 +122,6 @@ jobs:
           name: diff-pdf-${{ matrix.file }}
           path: diff-${{ matrix.file }}.pdf
           archive: false
-      - name: Upload diff marker
-        if: steps.diff_check.outcome == 'failure'
-        run: echo "true" > diff-marker.txt
-      - name: Upload diff marker artifact
-        if: steps.diff_check.outcome == 'failure'
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: diff-marker-${{ matrix.file }}
-          path: diff-marker.txt
 
   comment_pdf_diff:
     name: Comment PDF diff results
@@ -142,12 +131,12 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - name: Download diff markers
+      - name: Download diff PDFs
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
-          pattern: diff-marker-*
-          path: markers
+          pattern: diff-*
+          path: diffs
       - name: Build comment body
         id: build_comment
         run: |
@@ -155,15 +144,14 @@ jobs:
           BODY="> [!NOTE]"
           BODY="${BODY}\n> **PDF Differences Detected**"
           BODY="${BODY}\n>"
-          BODY="${BODY}\n> The following PDF outputs have changed between the main branch and this PR:"
+          BODY="${BODY}\n> The following PDF outputs have changed between the base branch and this PR:"
           BODY="${BODY}\n>"
 
-          for marker_dir in markers/diff-marker-*/; do
-            if [[ -d "$marker_dir" ]]; then
-              file_name=$(basename "$marker_dir" | sed 's/^diff-marker-//')
-              BODY="${BODY}\n> - \`${file_name}\` — download [\`diff-pdf-${file_name}\`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-              HAS_DIFF=true
-            fi
+          for diff in diffs/diff-*; do
+            file_name=$(basename "$diff" | sed 's/^diff-//')
+            echo "Found diff for ${file_name}"
+            BODY="${BODY}\n> - \`${file_name}\` — download [\`diff-${file_name}\`](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
+            HAS_DIFF=true
           done
 
           echo "has_diff=${HAS_DIFF}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Unfortunately my last change to the diff pipeline seemed to still not fix all the issues.

Download artifacts behaves differently when it matches one artifact or more than one artifact. For one artifact, it puts the downloaded file directly in a directory, for two or more artifacts, each artifact is put in their own directory, e.g. with `diff-main-dhbw-ka.pdf` and `diff-main-dhbw-ma.pdf`:

```
diff-main-dhbw-ka.pdf
\ diff-main-dhbw-ka.pdf
diff-main-dhbw-ma.pdf
\ diff-main-dhbw-ma.pdf
```

This leads to no changes being detected due to the `if [[ -f "$diff" ]]` check.

The solution is to enable the `merge-multiple` parameter, putting each file directly in the output directory.

As @haenoe suggested, this PR targets `main` as this change triggers no release and can therefore merged before `v2.0.0`.