### PR TITLE
feat: Change Appendix Deactivation

### DIFF
--- a/template/main-dhbw-ka.typ
+++ b/template/main-dhbw-ka.typ
@@ -84,7 +84,7 @@
   //   reference: "reference-label",
   //   content: [content] || include("appendix.typ")
   // )
-  // change to "appendices: none" to remove appendix
+  // remove property to remove appendices
   appendices: (
     (
       title: "Relevant Stuff",

--- a/template/main-dhbw-ma.typ
+++ b/template/main-dhbw-ma.typ
@@ -99,7 +99,7 @@
   //   reference: "reference-label",
   //   content: [content] || include("appendix.typ")
   // )
-  // change to "appendices: none" to remove appendix
+  // remove property to remove appendices
   appendices: (
     (
       title: "Relevant Stuff",

--- a/template/main-ihk.typ
+++ b/template/main-ihk.typ
@@ -35,7 +35,7 @@
   //   reference: "reference-label",
   //   content: [content] || include("appendix.typ")
   // )
-  // change to "appendices: none" to remove appendix
+  // remove property to remove appendices
   appendices: (
     (
       title: "Relevant Stuff",

--- a/template/template/base.typ
+++ b/template/template/base.typ
@@ -469,7 +469,7 @@
 
   // display appendix
   appendices = appendices.filter(item => (
-    item.title != none and item.reference != none
+    item.title != none and item.content != none
   ))
   if appendices.len() > 0 {
     set heading(

--- a/template/template/base.typ
+++ b/template/template/base.typ
@@ -468,7 +468,10 @@
   }
 
   // display appendix
-  if appendices != none {
+  appendices = appendices.filter(item => (
+    item.title != none and item.reference != none
+  ))
+  if appendices.len() > 0 {
     set heading(
       outlined: true,
       numbering: (..nums) => {


### PR DESCRIPTION
Currently users need to set the `appendices` property to `none` to deactivate the appendix. Omitting the property leads to the appendix TOC being printed without any entry.

I changed the API to a similar approach to how we handle the AI-Declaration: If an empty list is passed or if the property is omitted, the appendix TOC is not shown.

Thanks, @GilbertBckr, for making me aware of this issue.