### PR TITLE
Fix: only show lvl 1 headings in appendices list

### DIFF
--- a/template/assets/example-tables.typ
+++ b/template/assets/example-tables.typ
@@ -12,15 +12,12 @@ This appendix shows example tables. Sourced from #link("https://ieeexplore.ieee.
     [1],
     [Are there FPA problems being reported in terms of accuracy?],
     [Identify and summarize potential FPA problems, pointed out by researchers.],
-
     [2],
     [Are there proposals to improve the FPA’s accuracy? Which improvements are being proposed?],
     [Identify and summarize the approaches proposed to improve the FPA accuracy.],
-
     [3],
     [Are the proposed improvements effective?],
     [Verify if the proposed improvements are more effective when compared to the standard FPA.],
-
     [4],
     [What are the limitations for the proposed improvements?],
     [Identify potential problems or weaknesses for the proposed improvements.],

--- a/template/chapters/basic_formatting.typ
+++ b/template/chapters/basic_formatting.typ
@@ -8,7 +8,6 @@
   align: (_, row) => if row == 0 { center } else { horizon + left },
   table-content: (
     table.header("Typst Code", "Output"),
-
     align(horizon, box(width: 100%, raw(typst-code, lang: "typ", block: true))),
     box(width: 100%, {
       set heading(outlined: false)

--- a/template/template/base.typ
+++ b/template/template/base.typ
@@ -1,6 +1,8 @@
 // LTeX: enabled=false
 
-#import "@preview/glossarium:0.5.10": gls, glspl, make-glossary, print-glossary, register-glossary
+#import "@preview/glossarium:0.5.10": (
+  gls, glspl, make-glossary, print-glossary, register-glossary,
+)
 #import "@preview/hydra:0.6.2": hydra
 #import "@preview/codly:1.3.0": codly, codly-init
 #import "@preview/drafting:0.2.2": note-outline, set-margin-note-defaults

--- a/template/template/base.typ
+++ b/template/template/base.typ
@@ -1,8 +1,6 @@
 // LTeX: enabled=false
 
-#import "@preview/glossarium:0.5.10": (
-  gls, glspl, make-glossary, print-glossary, register-glossary,
-)
+#import "@preview/glossarium:0.5.10": gls, glspl, make-glossary, print-glossary, register-glossary
 #import "@preview/hydra:0.6.2": hydra
 #import "@preview/codly:1.3.0": codly, codly-init
 #import "@preview/drafting:0.2.2": note-outline, set-margin-note-defaults
@@ -493,7 +491,7 @@
     )
 
     outline(
-      depth: 3,
+      depth: 1,
       indent: auto,
       title: none,
       target: selector(heading).after(<__appendix-start>),


### PR DESCRIPTION
Fixes this odd looking outline:
<img width="651" height="142" alt="image" src="https://github.com/user-attachments/assets/d4541434-5ba2-41b7-9d76-b79a630756dc" />
