### PR TITLE
feat: Move from datetime to str input for dates

### DIFF
--- a/template/main-dhbw-ka.typ
+++ b/template/main-dhbw-ka.typ
@@ -53,8 +53,8 @@
 
   signature-city: "Karlsruhe",
 
-  // Set to specific date with datetime(year: 2026, month: 06, day: 10)
-  submission-date: datetime.today(),
+  // Set to specific date with "24.12.2026"
+  submission-date: datetime.today().display("[day].[month].[year]"),
 
   processing-period-weeks: 12,
 

--- a/template/main-dhbw-ma.typ
+++ b/template/main-dhbw-ma.typ
@@ -45,9 +45,9 @@
 
   signature-city: "Mannheim",
 
-  // Set to specific date with datetime(year: 2026, month: 06, day: 10)
-  submission-date: datetime.today(),
-  module-submission-date: datetime.today(),
+  // Set to specific date with "24.12.2026"
+  submission-date: datetime.today().display("[day].[month].[year]"),
+  module-submission-date: datetime.today().display("[day].[month].[year]"),
 
   processing-period-weeks: 12,
 

--- a/template/template/assets/ai-declaration-form_dhbw-ma.typ
+++ b/template/template/assets/ai-declaration-form_dhbw-ma.typ
@@ -9,8 +9,7 @@
   email: "",
   mobile-number: "",
   module-name: "",
-  module-submission-date: datetime.today(),
-  date-format: "dd. MMMM yyyy",
+  module-submission-date: datetime.today().display("[day].[month].[year]"),
   exam-type: "",
   product-name: "",
   topic: "",
@@ -18,7 +17,7 @@
   research: "",
   design: "",
   signature-city: "",
-  signature-date: datetime.today(),
+  signature-date: datetime.today().display("[day].[month].[year]"),
   signature-image: none,
 ) = {
   //parameters
@@ -30,9 +29,7 @@
   let fieldEmail = email + emptyFieldPlaceHolder
   let fieldMobileNumber = mobile-number + emptyFieldPlaceHolder
   let fieldModuleName = module-name + emptyFieldPlaceHolder
-  let fieldDate = [#module-submission-date.display(
-      date-format,
-    ) #emptyFieldPlaceHolder]
+  let fieldDate = [#module-submission-date #emptyFieldPlaceHolder]
   let examType = exam-type //"Projektarbeit I", "Projektarbeit II", "Seminararbeit",   Bachelorarbeit"
   let fieldProductName = product-name + emptyFieldPlaceHolder
   let fieldTopic = topic
@@ -45,7 +42,7 @@
   let signature
   if (digital) {
     fieldSignature = fieldPlaceHolder(
-      content: [#signature-city, #signature-date.display(date-format)],
+      content: [#signature-city, #signature-date],
     )
     signature = signature-image
   } else {
@@ -299,8 +296,11 @@
   email: "max.mustermann@dhbw-mannheim.de",
   mobile-number: "0171 1234567",
   module-name: "Projektmanagement",
-  module-submission-date: datetime(year: 2026, month: 06, day: 10),
-  date-format: "",
+  module-submission-date: datetime
+    .today()
+    .display(
+      "[day].[month].[year]",
+    ),
   exam-type: "Projektarbeit I", //"Projektarbeit I", "Projektarbeit II", "Seminararbeit",   Bachelorarbeit"
   product-name: "ChatGPT, DeepL",
   topic: "Automatisierung von Geschäftsprozessen",
@@ -308,5 +308,9 @@
   research: "Quellenrecherche mit KI",
   design: "Textgenerierung, Korrektur",
   signature-city: "Mannheim",
-  signature-date: datetime(year: 2026, month: 06, day: 10),
+  signature-date: datetime
+    .today()
+    .display(
+      "[day].[month].[year]",
+    ),
 )

--- a/template/template/base.typ
+++ b/template/template/base.typ
@@ -26,7 +26,7 @@
   digital: true,
   /// City name for the signature location. -> str | none
   city: none,
-  /// Date of the signature. -> datetime | none
+  /// Date of the signature. -> str | none
   date: none,
   /// Format string for displaying the date. (see #link("https://typst.app/docs/reference/foundations/datetime/#format")[datetime formats]) -> str
   date-format: "[day].[month].[year]",
@@ -37,10 +37,15 @@
     lastname: none,
   ),
 ) = {
+  // TODO: only for compatibility reasons: Remove with v3.0.0 release
+  if type(date) == datetime {
+    date = date.display(date-format)
+  }
+
   let signature-content = if digital {
     (
       city,
-      date.display(date-format),
+      date,
       [],
       grid.cell(
         if not author.keys().contains("signature") or author.signature == none {

--- a/template/template/dhbw-ka.typ
+++ b/template/template/dhbw-ka.typ
@@ -50,8 +50,8 @@
   ),
   /// City shown on the signature line. -> str
   signature-city: "Karlsruhe",
-  /// Submission date of the thesis. -> datetime
-  submission-date: datetime.today(),
+  /// Submission date of the thesis. -> str
+  submission-date: datetime.today().display("[day].[month].[year]"),
   /// Format string for displaying the submission date. (see #link("https://typst.app/docs/reference/foundations/datetime/#format")[datetime formats]) -> str
   submission-date-format: "[day].[month].[year]",
   /// Duration of the thesis processing period in weeks. -> int | none
@@ -89,10 +89,15 @@
     ))
   ]
 
+  // TODO: only for compatibility reasons: Remove with v3.0.0 release
+  if type(submission-date) == datetime {
+    submission-date = submission-date.display(submission-date-format)
+  }
+
   // Metadata
   let metadata = (
     __linguify-content("submission-date"),
-    submission-date.display(submission-date-format),
+    submission-date,
     __linguify-content("processing-duration"),
     __linguify-content("weeks", args: (count: processing-period-weeks)),
     __linguify-content("matriculation-number")
@@ -202,7 +207,6 @@
       __signature-line(
         author: a,
         date: submission-date,
-        date-format: submission-date-format,
         digital: digital-submission,
         city: signature-city,
       )

--- a/template/template/dhbw-ma.typ
+++ b/template/template/dhbw-ma.typ
@@ -45,10 +45,10 @@
   ),
   /// City shown on the signature line. -> str
   signature-city: "Mannheim",
-  /// Submission date of the thesis. -> datetime
-  submission-date: datetime.today(),
-  /// Submission date for the module (used in AI declaration form). -> datetime
-  module-submission-date: datetime.today(),
+  /// Submission date of the thesis. -> str
+  submission-date: datetime.today().display("[day].[month].[year]"),
+  /// Submission date for the module (used in AI declaration form). -> str
+  module-submission-date: datetime.today().display("[day].[month].[year]"),
   /// Format string for displaying dates. (see #link("https://typst.app/docs/reference/foundations/datetime/#format")[datetime formats]) -> str
   submission-date-format: "[day].[month].[year]",
   /// Duration of the thesis processing period in weeks. -> int | none
@@ -109,6 +109,18 @@
       city: linguify-raw("ma"),
     ))
   ]
+
+  // TODO: only for compatibility reasons: Remove with v3.0.0 release
+  if type(submission-date) == datetime {
+    submission-date = submission-date.display(submission-date-format)
+  }
+  // TODO: only for compatibility reasons: Remove with v3.0.0 release
+  if type(module-submission-date) == datetime {
+    module-submission-date = module-submission-date.display(
+      submission-date-format,
+    )
+  }
+
   let company-supervisor-data = [
     #company-supervisor.firstname #company-supervisor.lastname#if (
       company-supervisor.phone-number != none
@@ -135,7 +147,7 @@
 
   let metadata = (
     __linguify-content("submission-date"),
-    submission-date.display(submission-date-format),
+    submission-date,
     __linguify-content("processing-duration"),
     __linguify-content("weeks", args: (count: processing-period-weeks)),
     __linguify-content("matriculation-number")
@@ -217,7 +229,6 @@
       __signature-line(
         author: a,
         date: submission-date,
-        date-format: submission-date-format,
         digital: digital-submission,
         city: signature-city,
       )
@@ -247,7 +258,6 @@
     mobile-number: main-author.phone-number,
     module-name: ai-declaration-form-data.module-name,
     module-submission-date: module-submission-date,
-    date-format: submission-date-format,
     exam-type: ai-declaration-form-data.exam-type,
     product-name: ai-declaration-form-data.product-name,
     topic: ai-declaration-form-data.topic,

--- a/template/template/ihk.typ
+++ b/template/template/ihk.typ
@@ -35,8 +35,8 @@
   ),
   /// City shown on the signature line. -> str
   signature-city: "Karlsruhe",
-  /// Submission date of the thesis. -> datetime
-  submission-date: datetime.today(),
+  /// Submission date of the thesis. -> str
+  submission-date: datetime.today().display("[day].[month].[year]"),
   /// Format string for displaying the submission date. (see #link("https://typst.app/docs/reference/foundations/datetime/#format")[datetime formats]) -> str
   submission-date-format: "[day].[month].[year]",
   /// Duration of the thesis processing period in weeks. -> int | none
@@ -64,9 +64,15 @@
     #__linguify-content("in-the-training-occupation")\
     #training-occupation
   ]
+
+  // TODO: only for compatibility reasons: Remove with v3.0.0 release
+  if type(submission-date) == datetime {
+    submission-date = submission-date.display(submission-date-format)
+  }
+
   let metadata = (
     __linguify-content("submission-date"),
-    submission-date.display(submission-date-format),
+    submission-date,
     __linguify-content("processing-duration"),
     __linguify-content("weeks", args: (count: processing-period-weeks)),
     __linguify-content("examinee-number"),
@@ -96,7 +102,6 @@
       __signature-line(
         author: a,
         date: submission-date,
-        date-format: submission-date-format,
         digital: digital-submission,
         city: signature-city,
       )


### PR DESCRIPTION
Currently, when the user sets a date (such as the submission date), they have to set it as `datetime` with the (in my opinion) inconvenient syntax `datetime(year: 2026, month: 12, day: 24)`, and can provide a date format that gets used in `<datetime>.display(date-format)`.

In order to make things easier for our users, I switched to `str` type: Standard users can just input `"24.12.2026"`, more experienced users can use `datetime.today().display("[year]-[month]-[day]")` for instance if they need fancier logic.

For backwards-compatibility reasons, `datetime` types can still be used, but for release v3.0.0, we should remove the additional if-statements which ensure this. The documentation is already adjusted to `str`.