### PR TITLE
feat: Release 2.1.0

### DIFF
--- a/template/chapters/advanced_elements.typ
+++ b/template/chapters/advanced_elements.typ
@@ -100,6 +100,19 @@ You can reference labeled equations like other figures. @math-figure shows the s
 ]",
 )
 
+== Inline Glossary
+
+If you want to include parts of your glossary in your documents content this is possible using the `inline-glossary` function. This is useful if you need word definitions directly in a chapter and want the reader to explicitly read those definitions. The `group` parameter can be used to only show parts of the glossary. In the following example the _Dependency_ group of the example glossary defined in `glossary.typ` is shown. The _Dependency_ group contains definitions for @glossarium, @drafting, @codly, @hydra and @linguify, which are the packages used by this template.
+
+#typst-preview(
+  "Inline Glossary Showing the Templates Dependencies",
+  "#import \"../template/lib.typ\": inline-glossary
+#import \"../glossary.typ\": glossary
+
+#inline-glossary(glossary, (\"Dependencies\",), show-all: true)",
+)
+
+
 == Notes
 
 #import "@preview/drafting:0.2.2": inline-note, margin-note

--- a/template/glossary.typ
+++ b/template/glossary.typ
@@ -1,0 +1,59 @@
+// Specify abbreviations here.
+// The key is used to reference the acronym.
+// The short form is used every time and the long form is used
+// additionally the first time you reference the acronym.
+#let abbreviations = (
+  (key: "NN", short: "NN", long: "Neural Network"),
+  (key: "SG", short: "SG", long: "Singular"),
+)
+
+// Specify glossary terms here for term definitions (not abbreviations).
+// The key is used to reference the term.
+// The long form is the term and the short form is the abbreviation (only if you need it).
+// The description is used for the detailed explanation of the term.
+// Set to empty array () if you don't need a glossary.
+#let glossary = (
+  (
+    key: "typ",
+    short: "Typst",
+    description: "Typst is a new markup-based typesetting system that is designed to be as powerful as LaTeX while being much easier to learn and use.",
+  ),
+  (
+    key: "glossarium",
+    short: "Glossarium",
+    description: [Glossarium is a simple, easily customizable typst glossary inspired by the #link("https://www.ctan.org/pkg/glossaries", "LaTeX glossaries package")],
+    group: "Dependencies",
+  ),
+  (
+    key: "drafting",
+    short: "Drafting",
+    description: [
+      The Drafting package contains functions for content positioning and margin comments/notes.
+    ],
+    group: "Dependencies",
+  ),
+  (
+    key: "codly",
+    short: "Codly",
+    description: [
+      Codly provides styled code blocks with many features like smart indentation, line numbering, highlighting, etc.
+    ],
+    group: "Dependencies",
+  ),
+  (
+    key: "hydra",
+    short: "Hydra",
+    description: [
+      Hydra is a Typst package allowing easily displaying the current heading in the page header.
+    ],
+    group: "Dependencies",
+  ),
+  (
+    key: "linguify",
+    short: "Linguify",
+    description: [
+      Linguify brings #link("https://projectfluent.org/fluent/guide/", "fluent") support to typst, enabling easy i18n.
+    ],
+    group: "Dependencies",
+  ),
+)

--- a/template/main-dhbw-ka.typ
+++ b/template/main-dhbw-ka.typ
@@ -53,8 +53,8 @@
 
   signature-city: "Karlsruhe",
 
-  // Set to specific date with datetime(year: 2026, month: 06, day: 10)
-  submission-date: datetime.today(),
+  // Set to specific date with "24.12.2026"
+  submission-date: datetime.today().display("[day].[month].[year]"),
 
   processing-period-weeks: 12,
 

--- a/template/main-dhbw-ka.typ
+++ b/template/main-dhbw-ka.typ
@@ -1,5 +1,6 @@
 // LTeX: enabled=false
 #import "template/lib.typ": caption-with-source, dhbw-ka-adapter
+#import "glossary.typ": abbreviations, glossary
 
 #show: dhbw-ka-adapter.with(
   lang: "en",
@@ -106,28 +107,8 @@
   // Bibliography
   library: bibliography("refs.bib"),
 
-  // Specify abbreviations here.
-  // The key is used to reference the acronym.
-  // The short form is used every time and the long form is used
-  // additionally the first time you reference the acronym.
-  abbreviations: (
-    (key: "NN", short: "NN", long: "Neural Network"),
-    (key: "SG", short: "SG", long: "Singular"),
-  ),
-
-  // Specify glossary terms here for term definitions (not abbreviations).
-  // The key is used to reference the term.
-  // The long form is the term and the short form is the abbreviation (only if you need it).
-  // The description is used for the detailed explanation of the term.
-  // Set to empty array () if you don't need a glossary.
-  glossary: (
-    (
-      key: "typ",
-      short: none,
-      long: "Typst",
-      description: "Typst is a new markup-based typesetting system that is designed to be as powerful as LaTeX while being much easier to learn and use.",
-    ),
-  ),
+  abbreviations: abbreviations,
+  glossary: glossary,
 )
 
 // You can now start writing :)

--- a/template/main-dhbw-ka.typ
+++ b/template/main-dhbw-ka.typ
@@ -103,9 +103,8 @@
     ), // appendix from file
   ),
 
-  // Path to reference - either .yaml or .bib file
-  // * for `.yaml` files see: [hayagriva](https://github.com/typst/hayagriva)
-  library: "refs.bib",
+  // Bibliography
+  library: bibliography("refs.bib"),
 
   // Specify abbreviations here.
   // The key is used to reference the acronym.

--- a/template/main-dhbw-ma.typ
+++ b/template/main-dhbw-ma.typ
@@ -45,9 +45,9 @@
 
   signature-city: "Mannheim",
 
-  // Set to specific date with datetime(year: 2026, month: 06, day: 10)
-  submission-date: datetime.today(),
-  module-submission-date: datetime.today(),
+  // Set to specific date with "24.12.2026"
+  submission-date: datetime.today().display("[day].[month].[year]"),
+  module-submission-date: datetime.today().display("[day].[month].[year]"),
 
   processing-period-weeks: 12,
 

--- a/template/main-dhbw-ma.typ
+++ b/template/main-dhbw-ma.typ
@@ -72,6 +72,7 @@
 
   ai-declaration-form-data: (
     module-name: "Projektmanagement",
+    semester: "1",
     exam-type: "Projektarbeit I", // "Projektarbeit I", "Projektarbeit II", "Seminararbeit", "Bachelorarbeit"
     product-name: "ChatGPT, DeepL",
     topic: "Writing in Typst about a long, very scientific topic",

--- a/template/main-dhbw-ma.typ
+++ b/template/main-dhbw-ma.typ
@@ -129,9 +129,8 @@
     ), // appendix from file
   ),
 
-  // Path to reference - either .yaml or .bib file
-  // * for `.yaml` files see: [hayagriva](https://github.com/typst/hayagriva)
-  library: "refs.bib",
+  // Bibliography
+  library: bibliography("refs.bib"),
 
   // Specify abbreviations here.
   // The key is used to reference the acronym.

--- a/template/main-dhbw-ma.typ
+++ b/template/main-dhbw-ma.typ
@@ -34,12 +34,27 @@
       email: "john.doe@dhbw.com",
       address: "Example Street 1, 12345 Example City",
       phone-number: "+49 0000 0000",
+      // specific attributes for the ai declaration
+      ai-dec-product-name: "ChatGPT, DeepL",
+      ai-dec-topic: "Writing in Typst about a long, very scientific topic",
+      ai-dec-topic-editing: "Structuring, organizing",
+      ai-dec-research: "Research using AI",
+      ai-dec-design: "Text generation, correction",
     ), // make sure to keep this comma after the first author if there is only one author!
     (
       firstname: "Erika",
       lastname: "Musterfrau",
       matriculation-number: "1234567",
       course: "TINF23B1",
+      signature: none,
+      email: none,
+      address: none,
+      phone-number: none,
+      ai-dec-product-name: "ChatGPT, DeepL",
+      ai-dec-topic: "Writing in Typst about a long, very scientific topic",
+      ai-dec-topic-editing: "Structuring, organizing",
+      ai-dec-research: "Research using AI",
+      ai-dec-design: "Text generation, correction",
     ),
   ),
 
@@ -74,11 +89,6 @@
     module-name: "Projektmanagement",
     semester: "1",
     exam-type: "Projektarbeit I", // "Projektarbeit I", "Projektarbeit II", "Seminararbeit", "Bachelorarbeit"
-    product-name: "ChatGPT, DeepL",
-    topic: "Writing in Typst about a long, very scientific topic",
-    topic-editing: "Strukturierung, Gliederung",
-    research: "Quellenrecherche mit KI",
-    design: "Textgenerierung, Korrektur",
   ),
 
   // abstracs: usage: (language, language (displayed), content)

--- a/template/main-dhbw-ma.typ
+++ b/template/main-dhbw-ma.typ
@@ -1,5 +1,6 @@
 // LTeX: enabled=false
 #import "template/lib.typ": caption-with-source, dhbw-ma-adapter
+#import "glossary.typ": abbreviations, glossary
 
 #show: dhbw-ma-adapter.with(
   lang: "en",
@@ -132,28 +133,8 @@
   // Bibliography
   library: bibliography("refs.bib"),
 
-  // Specify abbreviations here.
-  // The key is used to reference the acronym.
-  // The short form is used every time and the long form is used
-  // additionally the first time you reference the acronym.
-  abbreviations: (
-    (key: "NN", short: "NN", long: "Neural Network"),
-    (key: "SG", short: "SG", long: "Singular"),
-  ),
-
-  // Specify glossary terms here for term definitions (not abbreviations).
-  // The key is used to reference the term.
-  // The long form is the term and the short form is the abbreviation (only if you need it).
-  // The description is used for the detailed explanation of the term.
-  // Set to empty array () if you don't need a glossary.
-  glossary: (
-    (
-      key: "typ",
-      short: none,
-      long: "Typst",
-      description: "Typst is a new markup-based typesetting system that is designed to be as powerful as LaTeX while being much easier to learn and use.",
-    ),
-  ),
+  abbreviations: abbreviations,
+  glossary: glossary,
 )
 
 // You can now start writing :)

--- a/template/main-ihk.typ
+++ b/template/main-ihk.typ
@@ -1,5 +1,6 @@
 // LTeX: enabled=false
 #import "template/lib.typ": caption-with-source, ihk-adapter
+#import "glossary.typ": abbreviations, glossary
 
 #show: ihk-adapter.with(
   lang: "de",
@@ -57,28 +58,8 @@
   // Bibliography
   library: bibliography("refs.bib"),
 
-  // Specify abbreviations here.
-  // The key is used to reference the acronym.
-  // The short form is used every time and the long form is used
-  // additionally the first time you reference the acronym.
-  abbreviations: (
-    (key: "NN", short: "NN", long: "Neural Network"),
-    (key: "SG", short: "SG", long: "Singular"),
-  ),
-
-  // Specify glossary terms here for term definitions (not abbreviations).
-  // The key is used to reference the term.
-  // The long form is the term and the short form is the abbreviation (only if you need it).
-  // The description is used for the detailed explanation of the term.
-  // Set to empty array () if you don't need a glossary.
-  glossary: (
-    (
-      key: "typ",
-      short: none,
-      long: "Typst",
-      description: "Typst is a new markup-based typesetting system that is designed to be as powerful as LaTeX while being much easier to learn and use.",
-    ),
-  ),
+  abbreviations: abbreviations,
+  glossary: glossary,
 )
 
 // You can now start writing :)

--- a/template/main-ihk.typ
+++ b/template/main-ihk.typ
@@ -54,8 +54,8 @@
     ), // appendix from file
   ),
 
-  // Path/s to references - .bib files
-  library: "refs.bib",
+  // Bibliography
+  library: bibliography("refs.bib"),
 
   // Specify abbreviations here.
   // The key is used to reference the acronym.

--- a/template/template/assets/ai-declaration-form_dhbw-ma.typ
+++ b/template/template/assets/ai-declaration-form_dhbw-ma.typ
@@ -9,8 +9,7 @@
   email: "",
   mobile-number: "",
   module-name: "",
-  module-submission-date: datetime.today(),
-  date-format: "dd. MMMM yyyy",
+  module-submission-date: datetime.today().display("[day].[month].[year]"),
   exam-type: "",
   product-name: "",
   topic: "",
@@ -18,7 +17,7 @@
   research: "",
   design: "",
   signature-city: "",
-  signature-date: datetime.today(),
+  signature-date: datetime.today().display("[day].[month].[year]"),
   signature-image: none,
 ) = {
   //parameters
@@ -30,9 +29,7 @@
   let fieldEmail = email + emptyFieldPlaceHolder
   let fieldMobileNumber = mobile-number + emptyFieldPlaceHolder
   let fieldModuleName = module-name + emptyFieldPlaceHolder
-  let fieldDate = [#module-submission-date.display(
-      date-format,
-    ) #emptyFieldPlaceHolder]
+  let fieldDate = [#module-submission-date #emptyFieldPlaceHolder]
   let examType = exam-type //"Projektarbeit I", "Projektarbeit II", "Seminararbeit",   Bachelorarbeit"
   let fieldProductName = product-name + emptyFieldPlaceHolder
   let fieldTopic = topic
@@ -45,7 +42,7 @@
   let signature
   if (digital) {
     fieldSignature = fieldPlaceHolder(
-      content: [#signature-city, #signature-date.display(date-format)],
+      content: [#signature-city, #signature-date],
     )
     signature = signature-image
   } else {
@@ -299,8 +296,11 @@
   email: "max.mustermann@dhbw-mannheim.de",
   mobile-number: "0171 1234567",
   module-name: "Projektmanagement",
-  module-submission-date: datetime(year: 2026, month: 06, day: 10),
-  date-format: "",
+  module-submission-date: datetime
+    .today()
+    .display(
+      "[day].[month].[year]",
+    ),
   exam-type: "Projektarbeit I", //"Projektarbeit I", "Projektarbeit II", "Seminararbeit",   Bachelorarbeit"
   product-name: "ChatGPT, DeepL",
   topic: "Automatisierung von Geschäftsprozessen",
@@ -308,5 +308,9 @@
   research: "Quellenrecherche mit KI",
   design: "Textgenerierung, Korrektur",
   signature-city: "Mannheim",
-  signature-date: datetime(year: 2026, month: 06, day: 10),
+  signature-date: datetime
+    .today()
+    .display(
+      "[day].[month].[year]",
+    ),
 )

--- a/template/template/assets/ai-declaration-form_dhbw-ma.typ
+++ b/template/template/assets/ai-declaration-form_dhbw-ma.typ
@@ -1,4 +1,5 @@
 //Declaration form for the use of AI-based tools in Projektarbeiten at DHBW Mannheim.
+#import "../utils.typ": __linguify-content
 
 #let ai-declaration-form(
   digital: true,
@@ -9,6 +10,8 @@
   email: "",
   mobile-number: "",
   module-name: "",
+  semester: "",
+  date-format: "dd. MMMM yyyy",
   module-submission-date: datetime.today().display("[day].[month].[year]"),
   exam-type: "",
   product-name: "",
@@ -21,48 +24,56 @@
   signature-image: none,
 ) = {
   //parameters
-  let emptyFieldPlaceHolder = box(height: 0.3cm)
-  let fieldName = name + emptyFieldPlaceHolder
-  let fieldIdentificatioNumber = identification-number + emptyFieldPlaceHolder
-  let fieldAddress = address + emptyFieldPlaceHolder
-  let fieldCourse = course + emptyFieldPlaceHolder
-  let fieldEmail = email + emptyFieldPlaceHolder
-  let fieldMobileNumber = mobile-number + emptyFieldPlaceHolder
-  let fieldModuleName = module-name + emptyFieldPlaceHolder
-  let fieldDate = [#module-submission-date #emptyFieldPlaceHolder]
-  let examType = exam-type //"Projektarbeit I", "Projektarbeit II", "Seminararbeit",   Bachelorarbeit"
-  let fieldProductName = product-name + emptyFieldPlaceHolder
-  let fieldTopic = topic
-  let fieldTopicEditing = topic-editing
-  let fieldResearch = research
-  let fieldDesign = design
-  let fieldSignature
+  let empty-field-placeholder = box(height: 0.3cm)
+  let field-name = name + empty-field-placeholder
+  let field-identification-number = (
+    identification-number + empty-field-placeholder
+  )
+  let field-address = address + empty-field-placeholder
+  let field-course = course + empty-field-placeholder
+  let field-email = email + empty-field-placeholder
+  let field-mobile-number = mobile-number + empty-field-placeholder
+  let field-module-name-semester = (
+    module-name
+      + empty-field-placeholder
+      + " / "
+      + empty-field-placeholder
+      + semester
+  )
+  let field-date = [#module-submission-date #empty-field-placeholder]
+  let exam-type = exam-type //"Projektarbeit I", "Projektarbeit II", "Seminararbeit",   Bachelorarbeit"
+  let field-production-name = product-name + empty-field-placeholder
+  let field-topic = topic
+  let field-topic-editing = topic-editing
+  let field-research = research
+  let field-design = design
+  let field-signature
 
-  let fieldPlaceHolder(content: []) = box(height: 2.6cm, content)
+  let field-placeholder(content: []) = box(height: 2.6cm, content)
   let signature
   if (digital) {
-    fieldSignature = fieldPlaceHolder(
+    field-signature = field-placeholder(
       content: [#signature-city, #signature-date],
     )
     signature = signature-image
   } else {
-    fieldSignature = fieldPlaceHolder()
-    signature = fieldPlaceHolder()
+    field-signature = field-placeholder()
+    signature = field-placeholder()
   }
 
   //measurements and styles
   let margin = (top: 2cm, right: 1.5cm, left: 2.5cm, bottom: 3cm)
-  let fontSizeNormal = 10pt
-  let fontSizeSmall = 7pt
-  let checkRec = [#sym.square]
-  let checkRecFilled = [#sym.square.filled]
+  let font-size-normal = 10pt
+  let font-size-small = 7pt
+  let check-rec = [#sym.square]
+  let check-rec-filled = [#sym.square.filled]
 
   //page settings
   set page(paper: "a4", margin: margin)
   set par(leading: 0.2cm, spacing: 0.4cm)
   set v(weak: true)
   set grid(inset: (top: 0.1cm, bottom: 0.1cm))
-  set text(size: fontSizeNormal, font: "Arial")
+  set text(size: font-size-normal, font: "Arial")
 
   show heading: it => {
     text(it.body) // Disable previous styling
@@ -71,7 +82,7 @@
   show heading.where(level: 2): set text(size: 10pt)
 
   //helpers
-  let textArea(lines: 4, content: []) = {
+  let text-area(lines: 4, content: []) = {
     if (digital == false) {
       content = []
       let n = 0
@@ -81,13 +92,17 @@
       }
       return content
     } else {
-      return block(height: 2.9cm, content)
+      return {
+        content
+        v(1cm)
+      }
     }
   }
-
-  let fillCheckRec(kind) = {
+  // takes the thesis kind in the form
+  // returns filled rec if the type is selected or not one of the placeholders
+  let rec(kind) = {
     if (
-      (kind == examType)
+      (kind == exam-type)
         or (
           (
             kind != "Projektarbeit I"
@@ -96,27 +111,41 @@
               and kind != "Bachelorarbeit"
           )
             and (
-              examType != "Projektarbeit I"
-                and examType != "Projektarbeit II"
-                and examType != "Seminararbeit"
-                and examType != "Bachelorarbeit"
+              exam-type != "Projektarbeit I"
+                and exam-type != "Projektarbeit II"
+                and exam-type != "Seminararbeit"
+                and exam-type != "Bachelorarbeit"
             )
         )
     ) {
-      return checkRecFilled + " " + kind
+      return check-rec-filled
     } else {
-      return checkRec + " " + kind
+      return check-rec
+    }
+  }
+  // takes the thesis type (e.g. 'Projektarbeit I, Bachelorarbeit')
+  // returns a rectangle (checked if the exam type equals the thesis type) and the thesis type
+  let fill-check-rec(kind) = {
+    if (not kind.starts-with("Projektarbeit")) {
+      return rec(kind) + " " + __linguify-content(lower(kind))
+    } else {
+      let a = lower(kind).split(" ")
+      return (
+        rec(kind)
+          + " "
+          + __linguify-content(a.at(0), args: (thesis-number: upper(a.at(1))))
+      )
     }
   }
 
-  let getOtherExamTypes() = {
+  let get-other-exam-types() = {
     if (
-      examType != "Projektarbeit I"
-        and examType != "Projektarbeit II"
-        and examType != "Seminararbeit"
-        and examType != "Bachelorarbeit"
+      exam-type != "Projektarbeit I"
+        and exam-type != "Projektarbeit II"
+        and exam-type != "Seminararbeit"
+        and exam-type != "Bachelorarbeit"
     ) {
-      return examType
+      return exam-type
     }
   }
 
@@ -126,53 +155,65 @@
     inset: 0cm,
     align(left, heading(
       level: 1,
-    )[Hilfsmittelangabe zum Einsatz von KI-basierten Werkzeugen bei der Anfertigung von wissenschaftlichen Arbeiten]),
+    )[#__linguify-content("ai-dec-title")]),
     align(right, image("DHBW-Logo.svg", width: 100%)),
   )
 
   v(0.7cm)
 
-  heading(level: 2, outlined: false)[Persönliche Angaben]
+  heading(level: 2, outlined: false)[#__linguify-content(
+    "ai-dec-personal-information",
+  )]
 
   v(1.1cm)
 
   {
-    set text(size: fontSizeSmall)
+    set text(size: font-size-small)
     let lineSpacing = 0.3cm
 
     grid(
       columns: (60%, 40%),
-      text(size: fontSizeNormal)[#fieldName],
-      text(size: fontSizeNormal)[#fieldIdentificatioNumber],
-      grid.cell(stroke: (top: 1pt))[Nachname, Vorname],
-      grid.cell(stroke: (top: 1pt))[Matrikelnummer],
+      text(size: font-size-normal)[#field-name],
+      text(size: font-size-normal)[#field-identification-number],
+      grid.cell(stroke: (top: 1pt))[#__linguify-content(
+        "ai-dec-last-first-name",
+      )],
+      grid.cell(stroke: (top: 1pt))[#__linguify-content(
+        "ai-dec-matriculation-number",
+      )],
       grid.cell(inset: lineSpacing, colspan: 2)[],
-      text(size: fontSizeNormal)[#fieldAddress],
-      text(size: fontSizeNormal)[#fieldCourse],
-      grid.cell(stroke: (top: 1pt))[Anschrift],
-      grid.cell(stroke: (top: 1pt))[Kurs],
+      text(size: font-size-normal)[#field-address],
+      text(size: font-size-normal)[#field-course],
+      grid.cell(stroke: (top: 1pt))[#__linguify-content("ai-dec-address")],
+      grid.cell(stroke: (top: 1pt))[#__linguify-content("ai-dec-course")],
       grid.cell(inset: lineSpacing, colspan: 2)[],
-      text(size: fontSizeNormal)[#fieldEmail],
-      text(size: fontSizeNormal)[#fieldMobileNumber],
-      grid.cell(stroke: (top: 1pt))[E-Mail],
-      grid.cell(stroke: (top: 1pt))[Telefonnummer /  Handynummer],
+      text(size: font-size-normal)[#field-email],
+      text(size: font-size-normal)[#field-mobile-number],
+      grid.cell(stroke: (top: 1pt))[#__linguify-content("ai-dec-mail")],
+      grid.cell(stroke: (top: 1pt))[#__linguify-content("ai-dec-tel-number")],
     )
 
     v(1.1cm)
 
     grid(
       columns: (3.4cm, 5.9cm, 8cm),
-      text(size: fontSizeNormal)[*Für das Modul*],
-      grid.cell(colspan: 2, text(size: fontSizeNormal)[#fieldModuleName]),
+      text(size: font-size-normal)[#__linguify-content("ai-dec-for-module")],
+      grid.cell(colspan: 2, text(
+        size: font-size-normal,
+      )[#field-module-name-semester]),
       [],
       grid.cell(
         colspan: 2,
         stroke: (top: 1pt),
         align: center,
-      )[Modulbezeichnung /   Semester],
-      text(size: fontSizeNormal)[*muss ich am*],
-      grid.cell(colspan: 2, text(size: fontSizeNormal)[#fieldDate]),
-      [], grid.cell(stroke: (top: 1pt), align: center)[Datum der Frist], [],
+      )[#__linguify-content("ai-dec-module-semester")],
+      text(size: font-size-normal)[#__linguify-content("ai-dec-have-to-on")],
+      grid.cell(colspan: 2, text(size: font-size-normal)[#field-date]),
+      [],
+      grid.cell(stroke: (top: 1pt), align: center)[#__linguify-content(
+        "ai-dec-deadline-date",
+      )],
+      [],
     )
   }
 
@@ -180,26 +221,27 @@
 
   pad(right: 1cm)[
 
-    *folgende Prüfungsleistung erbringen:*
+    #__linguify-content("ai-dec-following-examination")
     #v(0.35cm)
 
     #grid(
       columns: (4.2cm, 4.1cm, 1.7cm, 5.8cm),
-      [#fillCheckRec("Projektarbeit I")],
-      [#fillCheckRec("Projektarbeit II")],
-      [#fillCheckRec("Sonstige")],
-      [#h(2pt) #getOtherExamTypes()],
+      [#fill-check-rec("Projektarbeit I")],
+      [#fill-check-rec("Projektarbeit II")],
+      [#fill-check-rec("Sonstige")],
+      [#h(2pt) #get-other-exam-types()],
       grid.cell(colspan: 3)[],
       grid.cell(align: center, stroke: (top: 1pt), text(
-        size: fontSizeSmall,
-      )[genaue Bezeichnung]),
+        size: font-size-small,
+      )[#__linguify-content("specific-descr")]),
       grid.cell(colspan: 4, inset: (top: 0.15cm, bottom: 0pt))[],
-      [#fillCheckRec("Seminararbeit")], [#fillCheckRec("Bachelorarbeit")],
+      [#fill-check-rec("Seminararbeit")],
+      [#fill-check-rec("Bachelorarbeit")],
     )
 
     #v(2.2cm)
 
-    *Zur Verwendung KI-gestützter Werkzeuge erkläre ich in Kenntnis des Hinweisblatts   "Hinweise zum Einsatz von KI-basierten Werkzeugen bei der Anfertigung wissenschaftlicher  Arbeiten und die prüfungsrechtlichen Folgen ihres Einsatzes" Folgendes:*
+    #__linguify-content("ai-dec-intro")
   ]
 
   v(1cm)
@@ -211,12 +253,12 @@
       show text: strong
       list(
         spacing: 0.6cm,
-        [Ich habe mich aktiv über die Leistungsfähigkeit und Beschränkungen der in meiner   Arbeit eingesetzten KI-Werkzeuge informiert.],
-        [Bei der Anfertigung der Prüfungsleistung habe ich durchgehend eigenständig und beim  Einsatz KI-gestützter Werkzeuge maßgeblich steuernd gearbeitet.],
-        [Insbesondere habe ich die Inhalte entweder aus wissenschaftlichen oder anderen   zugelassenen Quellen entnommen und diese gekennzeichnet oder diese unter Anwendung  wissenschaftlicher Methoden selbst entwickelt.],
-        [Mir ist bewusst, dass ich als Autor/in der Arbeit die Verantwortung für die in ihr   gemachten Angaben und Aussagen trage.],
-        [Ich habe keine weiteren als die nachstehend von mir benannten KI-gestützten Werk-  zeuge zur Erstellung der Arbeit eingesetzt und diese nur in der angegebenen Art und  Weise.],
-        [Soweit ich KI-gestützte Werkzeuge zur Erstellung der Arbeit eingesetzt habe, gebe  ich diese in der nachstehenden "Übersicht verwendeter Hilfsmittel" mit ihrem   Produkt-\ namen und ihres genutzten Funktionsumfangs vollständig an; wörtliche oder   sinn- gemäße Übernahmen KI-generierter Inhalte habe ich in ein separates Verzeichnis  aufgenommen und im Text belegt (z. B. als Fußnote). Diese Inhalte sind als pdf-Datei   in den elektronischen Beigaben hinterlegt.],
+        [#__linguify-content("ai-dec-informed-performance-restrictions")],
+        [#__linguify-content("ai-dec-independence-controlling")],
+        [#__linguify-content("ai-dec-scientific-independent-work")],
+        [#__linguify-content("ai-dec-scientific-responsibility")],
+        [#__linguify-content("ai-dec-no-other-tools")],
+        [#__linguify-content("ai-dec-all-specified")],
       )
     }
   ]
@@ -226,11 +268,12 @@
   pad(right: 1.1cm)[
     #set par(justify: true)
 
-    *#underline[Produktname] (n) eingesetzter Hilfsmittel:*
+    #underline(__linguify-content("ai-dec-title-products-first"))
+    #__linguify-content("ai-dec-title-products-second")
     #{
       if (digital) {
         v(0.7cm)
-        fieldProductName
+        field-production-name
       } else {
         v(1cm)
         line(length: 100%)
@@ -239,35 +282,35 @@
 
     #v(1.3cm)
 
-    *#underline[Genutzter Funktionsumfang] im Hinblick auf:*
+    #__linguify-content("ai-dec-title-used-functions")
     #v(1cm)
 
-    - *Themenerfassung und Strukturierung* (Aufgabenstellung oder Präzisierung,   Forschungsansatz, Gliederung)
+    - #__linguify-content("ai-dec-topic-structure")
     #v(1cm)
-    #textArea(content: fieldTopic)
+    #text-area(content: field-topic)
 
-    - *Themenbearbeitung* (Darstellung/Beschreibung des Problems, Darlegung von   wissenschaft-\ lichen Grundlagen, Schlussfolgerungen allgemein und für das konkrete   Thema / Erkenntnisgewinn, Evaluierung des Textes / Feedback der KI)
+    - #__linguify-content("ai-dec-topic-processing")
     #v(1cm)
-    #textArea(content: topic-editing)
+    #text-area(content: topic-editing)
 
-    - *Quellenrecherche, -auswahl und -auswertung* (welche Quellen wurden durch das KI-\  Werkzeug gefunden, wie erfolgte die weitere Recherche)
+    - #__linguify-content("ai-dec-research-choose")
     #v(1cm)
-    #textArea(content: research)
+    #text-area(content: research)
 
     #set par(justify: false)
 
-    - *Formale Gestaltung, insbesondere Sprache* (Welche Eingabe wurde an die KI getätigt?  Textgenerierung, Textkorrektur, Paraphrasieren und Umschreiben, Übersetzen, kreatives  Schreiben)
+    - #__linguify-content("ai-dec-formal-design")
     #v(1cm)
-    #textArea(content: design)
+    #text-area(content: design)
   ]
 
   v(1.8cm)
 
   pad(right: 0.5cm)[
     #block(stroke: 0.5pt, inset: 3pt)[
-      *Hinweis*:
+      #__linguify-content("notice")
 
-      Geben Sie in der jeweiligen Rubrik die Seitenzahl in ihrer wissenschaftlichen Arbeit an   und erläutern Sie die Art und Weise sowie den Umfang der von Ihnen genutzten  KI-basierten Werkzeuge.
+      #__linguify-content("ai-dec-notice")
     ]
   ]
   v(1.6cm)
@@ -279,10 +322,10 @@
   grid(
     columns: (4.9cm, 10.1cm),
     column-gutter: 0.5cm,
-    align(bottom, text(size: fontSizeNormal, fieldSignature)),
+    align(bottom, text(size: font-size-normal, field-signature)),
     place(bottom, signature),
-    grid.cell(stroke: (top: 1pt), [*Ort, Datum*]),
-    grid.cell(stroke: (top: 1pt), [*Unterschrift der/des Studierenden*]),
+    grid.cell(stroke: (top: 1pt), [#__linguify-content("place-date")]),
+    grid.cell(stroke: (top: 1pt), [#__linguify-content("signature-student")]),
   )
 }
 
@@ -304,9 +347,9 @@
   exam-type: "Projektarbeit I", //"Projektarbeit I", "Projektarbeit II", "Seminararbeit",   Bachelorarbeit"
   product-name: "ChatGPT, DeepL",
   topic: "Automatisierung von Geschäftsprozessen",
-  topic-editing: "Strukturierung, Gliederung",
-  research: "Quellenrecherche mit KI",
-  design: "Textgenerierung, Korrektur",
+  topic-editing: __linguify-content("ai-dec-structure"),
+  research: __linguify-content("ai-dec-research-ai"),
+  design: __linguify-content("ai-dec-generation-correction"),
   signature-city: "Mannheim",
   signature-date: datetime
     .today()

--- a/template/template/assets/ai-declaration-form_dhbw-ma.typ
+++ b/template/template/assets/ai-declaration-form_dhbw-ma.typ
@@ -11,7 +11,6 @@
   mobile-number: "",
   module-name: "",
   semester: "",
-  date-format: "dd. MMMM yyyy",
   module-submission-date: datetime.today().display("[day].[month].[year]"),
   exam-type: "",
   product-name: "",

--- a/template/template/base.typ
+++ b/template/template/base.typ
@@ -26,7 +26,7 @@
   digital: true,
   /// City name for the signature location. -> str | none
   city: none,
-  /// Date of the signature. -> datetime | none
+  /// Date of the signature. -> str | none
   date: none,
   /// Format string for displaying the date. (see #link("https://typst.app/docs/reference/foundations/datetime/#format")[datetime formats]) -> str
   date-format: "[day].[month].[year]",
@@ -37,10 +37,15 @@
     lastname: none,
   ),
 ) = {
+  // TODO: only for compatibility reasons: Remove with v3.0.0 release
+  if type(date) == datetime {
+    date = date.display(date-format)
+  }
+
   let signature-content = if digital {
     (
       city,
-      date.display(date-format),
+      date,
       [],
       grid.cell(
         if not author.keys().contains("signature") or author.signature == none {

--- a/template/template/base.typ
+++ b/template/template/base.typ
@@ -153,6 +153,8 @@
   // load linguify
   set-database(eval(load-ftl-data("l10n", ("en", "de"))))
 
+  set bibliography(title: __linguify-content("bibliography"))
+
   // page setup
   set document(title: title-long)
   set page(paper: "a4", margin: (rest: 2.5cm))
@@ -413,10 +415,15 @@
   set page(numbering: "a", footer: auto)
   counter(page).update(1)
 
-  bibliography(
-    "../" + library,
-    title: __linguify-content("bibliography"),
-  )
+  // This is just for supporting the old method of usage, but it is deprecated
+  // TODO: probably rework with Typst 0.15.0
+  if type(library) == str {
+    bibliography(
+      "../" + library,
+    )
+  } else {
+    library
+  }
 
   // lists and declarations (between content and appendix)
   {

--- a/template/template/dhbw-ka.typ
+++ b/template/template/dhbw-ka.typ
@@ -50,8 +50,8 @@
   ),
   /// City shown on the signature line. -> str
   signature-city: "Karlsruhe",
-  /// Submission date of the thesis. -> datetime
-  submission-date: datetime.today(),
+  /// Submission date of the thesis. -> str
+  submission-date: datetime.today().display("[day].[month].[year]"),
   /// Format string for displaying the submission date. (see #link("https://typst.app/docs/reference/foundations/datetime/#format")[datetime formats]) -> str
   submission-date-format: "[day].[month].[year]",
   /// Duration of the thesis processing period in weeks. -> int | none
@@ -89,10 +89,15 @@
     ))
   ]
 
+  // TODO: only for compatibility reasons: Remove with v3.0.0 release
+  if type(submission-date) == datetime {
+    submission-date = submission-date.display(submission-date-format)
+  }
+
   // Metadata
   let metadata = (
     __linguify-content("submission-date"),
-    submission-date.display(submission-date-format),
+    submission-date,
     __linguify-content("processing-duration"),
     __linguify-content("weeks", args: (count: processing-period-weeks)),
     __linguify-content("matriculation-number")
@@ -202,7 +207,6 @@
       __signature-line(
         author: a,
         date: submission-date,
-        date-format: submission-date-format,
         digital: digital-submission,
         city: signature-city,
       )

--- a/template/template/dhbw-ma.typ
+++ b/template/template/dhbw-ma.typ
@@ -45,10 +45,10 @@
   ),
   /// City shown on the signature line. -> str
   signature-city: "Mannheim",
-  /// Submission date of the thesis. -> datetime
-  submission-date: datetime.today(),
-  /// Submission date for the module (used in AI declaration form). -> datetime
-  module-submission-date: datetime.today(),
+  /// Submission date of the thesis. -> str
+  submission-date: datetime.today().display("[day].[month].[year]"),
+  /// Submission date for the module (used in AI declaration form). -> str
+  module-submission-date: datetime.today().display("[day].[month].[year]"),
   /// Format string for displaying dates. (see #link("https://typst.app/docs/reference/foundations/datetime/#format")[datetime formats]) -> str
   submission-date-format: "[day].[month].[year]",
   /// Duration of the thesis processing period in weeks. -> int | none
@@ -109,6 +109,18 @@
       city: linguify-raw("ma"),
     ))
   ]
+
+  // TODO: only for compatibility reasons: Remove with v3.0.0 release
+  if type(submission-date) == datetime {
+    submission-date = submission-date.display(submission-date-format)
+  }
+  // TODO: only for compatibility reasons: Remove with v3.0.0 release
+  if type(module-submission-date) == datetime {
+    module-submission-date = module-submission-date.display(
+      submission-date-format,
+    )
+  }
+
   let company-supervisor-data = [
     #company-supervisor.firstname #company-supervisor.lastname#if (
       company-supervisor.phone-number != none
@@ -135,7 +147,7 @@
 
   let metadata = (
     __linguify-content("submission-date"),
-    submission-date.display(submission-date-format),
+    submission-date,
     __linguify-content("processing-duration"),
     __linguify-content("weeks", args: (count: processing-period-weeks)),
     __linguify-content("matriculation-number")
@@ -217,7 +229,6 @@
       __signature-line(
         author: a,
         date: submission-date,
-        date-format: submission-date-format,
         digital: digital-submission,
         city: signature-city,
       )
@@ -247,7 +258,6 @@
     mobile-number: main-author.phone-number,
     module-name: ai-declaration-form-data.module-name,
     module-submission-date: module-submission-date,
-    date-format: submission-date-format,
     exam-type: ai-declaration-form-data.exam-type,
     product-name: ai-declaration-form-data.product-name,
     topic: ai-declaration-form-data.topic,

--- a/template/template/dhbw-ma.typ
+++ b/template/template/dhbw-ma.typ
@@ -85,6 +85,7 @@
   /// `position` ("preamble", "postamble", or "after-confidentiality-clause"). -> dictionary
   ai-declaration-form-data: (
     module-name: none,
+    semester: none,
     exam-type: none,
     product-name: none,
     topic: none,
@@ -250,13 +251,14 @@
 
   let ai-tools-declaration = ai-declaration-form(
     digital: digital-only,
-    name: main-author.firstname + " " + main-author.lastname,
+    name: main-author.lastname + ", " + main-author.firstname,
     identification-number: main-author.matriculation-number,
     address: main-author.address,
     course: main-author.course,
     email: main-author.email,
     mobile-number: main-author.phone-number,
     module-name: ai-declaration-form-data.module-name,
+    semester: ai-declaration-form-data.semester,
     module-submission-date: module-submission-date,
     exam-type: ai-declaration-form-data.exam-type,
     product-name: ai-declaration-form-data.product-name,

--- a/template/template/dhbw-ma.typ
+++ b/template/template/dhbw-ma.typ
@@ -41,6 +41,11 @@
       email: none,
       address: none,
       phone-number: none,
+      ai-dec-product-name: none,
+      ai-dec-topic: none,
+      ai-dec-topic-editing: none,
+      ai-dec-research: none,
+      ai-dec-design: none,
     ),
   ),
   /// City shown on the signature line. -> str
@@ -247,30 +252,31 @@
     __linguify-content("confidentiality-agreement-note-dhbw")
   }
 
-  let main-author = authors.at(0)
-
-  let ai-tools-declaration = ai-declaration-form(
-    digital: digital-only,
-    name: main-author.lastname + ", " + main-author.firstname,
-    identification-number: main-author.matriculation-number,
-    address: main-author.address,
-    course: main-author.course,
-    email: main-author.email,
-    mobile-number: main-author.phone-number,
-    module-name: ai-declaration-form-data.module-name,
-    semester: ai-declaration-form-data.semester,
-    module-submission-date: module-submission-date,
-    exam-type: ai-declaration-form-data.exam-type,
-    product-name: ai-declaration-form-data.product-name,
-    topic: ai-declaration-form-data.topic,
-    topic-editing: ai-declaration-form-data.topic-editing,
-    research: ai-declaration-form-data.research,
-    design: ai-declaration-form-data.design,
-    signature-city: signature-city,
-    signature-date: submission-date,
-    signature-image: main-author.signature,
-  )
-
+  let ai-declarations = ()
+  for a in authors {
+    let ai-declaration = ai-declaration-form(
+      digital: digital-only,
+      name: a.lastname + ", " + a.firstname,
+      identification-number: a.matriculation-number,
+      address: a.address,
+      course: a.course,
+      email: a.email,
+      mobile-number: a.phone-number,
+      module-name: ai-declaration-form-data.module-name,
+      semester: ai-declaration-form-data.semester,
+      module-submission-date: module-submission-date,
+      exam-type: ai-declaration-form-data.exam-type,
+      product-name: a.ai-dec-product-name,
+      topic: a.ai-dec-topic,
+      topic-editing: a.ai-dec-topic-editing,
+      research: a.ai-dec-research,
+      design: a.ai-dec-design,
+      signature-city: signature-city,
+      signature-date: submission-date,
+      signature-image: a.signature,
+    )
+    ai-declarations.push(ai-declaration)
+  }
   show: project.with(
     __logo-left: company-logo,
     __logo-right: image("assets/DHBW-Logo.svg"),
@@ -281,7 +287,7 @@
     __postamble: (
       statutory-declaration,
       ..if (confidentiality-clause) { (confidentiality-clause-text,) },
-      ai-tools-declaration,
+      ..ai-declarations,
     ),
     ..args,
   )

--- a/template/template/ihk.typ
+++ b/template/template/ihk.typ
@@ -35,8 +35,8 @@
   ),
   /// City shown on the signature line. -> str
   signature-city: "Karlsruhe",
-  /// Submission date of the thesis. -> datetime
-  submission-date: datetime.today(),
+  /// Submission date of the thesis. -> str
+  submission-date: datetime.today().display("[day].[month].[year]"),
   /// Format string for displaying the submission date. (see #link("https://typst.app/docs/reference/foundations/datetime/#format")[datetime formats]) -> str
   submission-date-format: "[day].[month].[year]",
   /// Duration of the thesis processing period in weeks. -> int | none
@@ -64,9 +64,15 @@
     #__linguify-content("in-the-training-occupation")\
     #training-occupation
   ]
+
+  // TODO: only for compatibility reasons: Remove with v3.0.0 release
+  if type(submission-date) == datetime {
+    submission-date = submission-date.display(submission-date-format)
+  }
+
   let metadata = (
     __linguify-content("submission-date"),
-    submission-date.display(submission-date-format),
+    submission-date,
     __linguify-content("processing-duration"),
     __linguify-content("weeks", args: (count: processing-period-weeks)),
     __linguify-content("examinee-number"),
@@ -96,7 +102,6 @@
       __signature-line(
         author: a,
         date: submission-date,
-        date-format: submission-date-format,
         digital: digital-submission,
         city: signature-city,
       )

--- a/template/template/l10n/de.ftl
+++ b/template/template/l10n/de.ftl
@@ -79,6 +79,46 @@ statutory-declaration-note-dhbw-old-printed = { $author-count ->
 
 confidentiality-agreement-note-dhbw = Der Inhalt dieser Arbeit darf weder als Ganzes noch in Auszügen Personen außerhalb des Prüfungsprozesses und des Evaluationsverfahrens zugänglich gemacht werden, sofern keine anderslautende Genehmigung des Dualen Partners vorliegt.
 ai-acknowledgement-heading-dhbw = Anmerkung zur Nutzung von Künstlicher Intelligenz
+#### MA
+ai-dec-title = Hilfsmittelangabe zum Einsatz von KI-basierten Werkzeugen bei der Anfertigung von wissenschaftlichen Arbeiten
+ai-dec-personal-information = Persönliche Angaben
+ai-dec-last-first-name = Nachname, Vorname
+ai-dec-matriculation-number = Matrikelnummer
+ai-dec-address = Anschrift
+ai-dec-course = Kurs
+ai-dec-mail = E-Mail
+ai-dec-tel-number = Telefonnummer /  Handynummer
+ai-dec-for-module = *Für das Modul*
+ai-dec-module-semester = Modulbezeichnung / Semester
+ai-dec-have-to-on = *Muss ich am*
+ai-dec-deadline-date = Datum der Frist
+ai-dec-following-examination = *Folgende Prüfungsleistung erbringen*
+projektarbeit = Projektarbeit {$thesis-number}
+sonstige = Sonstige
+specific-descr = genaue Bezeichnung
+seminararbeit = Seminararbeit
+bachelorarbeit = Bachelorarbeit
+notice = *Hinweis:*
+place-date = *Ort, Datum*
+signature-student = *Unterschrift der/des Studierenden*
+ai-dec-intro = *Zur Verwendung KI-gestützter Werkzeuge erkläre ich in Kenntnis des Hinweisblatts "Hinweise zum Einsatz von KI-basierten Werkzeugen bei der Anfertigung wissenschaftlicher Arbeiten und die prüfungsrechtlichen Folgen ihres Einsatzes" Folgendes:*
+ai-dec-informed-performance-restrictions = Ich habe mich aktiv über die Leistungsfähigkeit und Beschränkungen der in meiner Arbeit eingesetzten KI-basierten Werkzeuge informiert.
+ai-dec-independence-controlling = Bei der Anfertigung der Prüfungsleistung habe ich durchgehend eigenständig und beim Einsatz KI-gestützter Werkzeuge maßgeblich steuernd gearbeitet.
+ai-dec-scientific-independent-work = Insbesondere habe ich die Inhalte entweder aus wissenschaftlichen oder anderen zugelassenen Quellen entnommen und diese gekennzeichnet oder diese unter Anwendung wissenschaftlicher Methoden selbst entwickelt.
+ai-dec-scientific-responsibility = Mir ist bewusst, dass ich als Autor/in der Arbeit die Verantwortung für die in ihr gemachten Angaben und Aussagen trage.
+ai-dec-no-other-tools = Ich habe keine weiteren als die nachstehend von mir benannten KI-gestützten Werk-  zeuge zur Erstellung der Arbeit eingesetzt und diese nur in der angegebenen Art und  Weise.
+ai-dec-all-specified = Soweit ich KI-gestützte Werkzeuge zur Erstellung der Arbeit eingesetzt habe, gebe  ich diese in der nachstehenden "Übersicht verwendeter Hilfsmittel" mit ihrem   Produkt-\ namen und ihres genutzten Funktionsumfangs vollständig an; wörtliche oder   sinn- gemäße Übernahmen KI-generierter Inhalte habe ich in ein separates Verzeichnis  aufgenommen und im Text belegt (z. B. als Fußnote). Diese Inhalte sind als pdf-Datei   in den elektronischen Beigaben hinterlegt.
+ai-dec-title-products-first = *Produktname*
+ai-dec-title-products-second = *(n) eingesetzter Hilfsmittel:*
+ai-dec-title-used-functions = *_Genutzter Funktionsumfang_ im Hinblick auf:*
+ai-dec-topic-structure = *Themenerfassung und Strukturierung* (Aufgabenstellung oder Präzisierung, Forschungsansatz, Gliederung)
+ai-dec-topic-processing = *Themenbearbeitung* (Darstellung/Beschreibung des Problems, Darlegung von   wissenschaft-\ lichen Grundlagen, Schlussfolgerungen allgemein und für das konkrete   Thema / Erkenntnisgewinn, Evaluierung des Textes / Feedback der KI)
+ai-dec-structure = Strukturierung, Gliederung
+ai-dec-research-choose = *Quellenrecherche, -auswahl und -auswertung* (welche Quellen wurden durch das KI-\  Werkzeug gefunden, wie erfolgte die weitere Recherche)
+ai-dec-research-ai = Quellenrecherche mit KI
+ai-dec-formal-design = *Formale Gestaltung, insbesondere Sprache* (Welche Eingabe wurde an die KI getätigt?  Textgenerierung, Textkorrektur, Paraphrasieren und Umschreiben, Übersetzen, kreatives  Schreiben)
+ai-dec-generation-correction = Textgenerierung, Korrektur
+ai-dec-notice = Geben Sie in der jeweiligen Rubrik die Seitenzahl in ihrer wissenschaftlichen Arbeit an   und erläutern Sie die Art und Weise sowie den Umfang der von Ihnen genutzten  KI-basierten Werkzeuge.
 
 ### IHK
 as-part-of-examination-ihk = Im Rahmen der

--- a/template/template/l10n/en.ftl
+++ b/template/template/l10n/en.ftl
@@ -79,6 +79,47 @@ statutory-declaration-note-dhbw-old-printed = { $author-count ->
 
 confidentiality-agreement-note-dhbw = The contents of this work may not be made accessible, in whole or in part, to persons outside the examination process and the evaluation procedure, unless otherwise authorized by the Dual Partner.
 ai-acknowledgement-heading-dhbw = AI Acknowledgement
+#### MA
+ai-dec-title = Declaration on the Use of AI-Based Tools in Scientific Works
+ai-dec-personal-information = Personal Information
+ai-dec-last-first-name = Last Name, First Name
+ai-dec-matriculation-number = Matriculation Number
+ai-dec-address = Address
+ai-dec-course = Course
+ai-dec-mail = E-Mail
+ai-dec-tel-number = Call Number
+ai-dec-for-module = *For the Module*
+ai-dec-module-semester = Module Name / Semester
+ai-dec-have-to-on = *On*
+ai-dec-deadline-date = Date of the Deadline
+ai-dec-following-examination = *I have to complete the following examination:*
+projektarbeit = Project Thesis {$thesis-number}
+sonstige = others
+specific-descr = Specific Description
+seminararbeit = Seminar Thesis
+bachelorarbeit = Bachelor Thesis
+notice = *Notice:*
+ai-dec-notice = In the designated section, specify the page number in your academic paper and explain the manner and extent of the AI-based tools you utilized.
+place-date = *Place, Date*
+signature-student = *Signature Student*
+ai-dec-intro = *For the use of AI-based tools, taking note of the declaration paper: "Hinweise zum Einsatz von KI-basierten Werkzeugen bei der Anfertigung wissenschaftlicher Arbeiten und die prüfungsrechtlichen Folgen ihres Einsatzes", I declare the following:*
+ai-dec-informed-performance-restrictions = I actively informed myself about the capabilities and limitations of the AI-based tools used in my work.
+ai-dec-informed-capabilities-restrictions = I have informed myself about the capabilities and restrictions of the AI-based tools used in my thesis.
+ai-dec-independence-controlling = During the creation process of this examination work, I continuously worked independently and within the use of AI-based tools I worked significantly controlling.
+ai-dec-scientific-independent-work = In particular I either derived the content from scientific or other authorized sources and marked them, or I developed them myself using scientific methods.
+ai-dec-scientific-responsibility = I am aware that I (as the author) take the responsibility for all information and statements in the thesis.
+ai-dec-no-other-tools = I did not use any AI-based tools for the creation of this work other than those specified below, and have used them only in the manner indicated.
+ai-dec-all-specified = To the extent that I have utilized AI-assisted tools in the preparation of this work, I have fully disclosed them including their product names and the specific functions employed in the "Overview of Used Tools" provided below. I have compiled any verbatim or paraphrased excerpts of AI-generated content into a separate appendix and have duly cited them within the text (e.g., via footnotes). These contents are included as a PDF file within the accompanying electronic supplements.
+ai-dec-title-products-first = *Product Name*
+ai-dec-title-products-second = *(s) of Tools used:*
+ai-dec-title-used-functions = *_Scope of functionality_ utilized with regard to:*
+ai-dec-topic-structure = *Topic Analysis and Structuring* (Assignment or Refinement, Research Approach, Outline)
+ai-dec-topic-processing = *Treatment of the Topic* (Presentation/description of the problem, exposition of scientific foundations, conclusions both general and specific to the topic at hand / insights gained, evaluation of the text / AI feedback)
+ai-dec-structure = Structuring
+ai-dec-research-choose = *Source Research, Selection, and Analysis* (which sources were identified by the AI ​​tool, and how was subsequent research conducted?)
+ai-dec-research-ai = Source Research with AI
+ai-dec-formal-design = *Formal Design, Specifically Language* (What input was provided to the AI? Text generation, text correction, paraphrasing and rewriting, translation, creative writing)
+ai-dec-generation-correction = Text Generation, Proofreading
 
 ### IHK
 as-part-of-examination-ihk = as part of the

--- a/template/template/lib.typ
+++ b/template/template/lib.typ
@@ -6,7 +6,7 @@
 #import "dhbw-ma.typ": dhbw-ma-adapter
 #import "ihk.typ": ihk-adapter
 #import "utils.typ": (
-  caption-with-source, styled-table, table-hline-spaced, tablefigure,
-  tablefigure-raw,
+  caption-with-source, inline-glossary, styled-table, table-hline-spaced,
+  tablefigure, tablefigure-raw,
 )
 #import "base.typ": project

--- a/template/template/utils.typ
+++ b/template/template/utils.typ
@@ -1,6 +1,7 @@
 // LTeX: enabled=false
 
 #import "@preview/linguify:0.5.0": linguify-raw
+#import "@preview/glossarium:0.5.10": print-glossary
 
 /// Internal state to track whether we are currently rendering an outline.
 /// -> state
@@ -231,4 +232,60 @@
 
 #let __linguify-content(..args) = {
   context eval(linguify-raw(..args), mode: "markup")
+}
+
+/// Displays a glossary without interfering with the glossary shown at the end of the document.
+///
+/// Usefull when wanting to display part of a glossary in the document content.
+///
+/// Wraps `print-glossary` by `glossarium`. See the #link("https://typst.app/universe/package/glossarium/")[glossarium documentation] for more information.
+///
+/// -> content
+#let inline-glossary(
+  /// The list of entries -> array
+  entry-list,
+  /// The list of groups to display (only included groups will be shown the rest will be hidden) -> array
+  groups,
+  /// Whether to show group headings or not -> bool
+  display-headings: false,
+  /// Additional arguments passed to `print-glossary` -> arguments
+  ..args,
+) = {
+  let custom-print-reference(
+    entry,
+    show-all: false,
+    disable-back-references: false,
+    deduplicate-back-references: false,
+    minimum-refs: 1,
+    description-separator: ": ",
+    shorthands: none,
+    user-print-gloss: none,
+    user-print-title: none,
+    user-print-description: none,
+    user-print-back-references: none,
+  ) = {
+    user-print-gloss(
+      entry,
+      show-all: show-all,
+      disable-back-references: true,
+      deduplicate-back-references: deduplicate-back-references,
+      minimum-refs: minimum-refs,
+      description-separator: description-separator,
+      user-print-title: user-print-title,
+      user-print-description: user-print-description,
+      user-print-back-references: user-print-back-references,
+    )
+  }
+
+  let args-cp = args.named()
+  if not display-headings {
+    args-cp.insert("user-print-group-heading", (..args) => {})
+  }
+
+  print-glossary(
+    entry-list,
+    groups: groups,
+    user-print-reference: custom-print-reference,
+    ..args-cp,
+  )
 }


### PR DESCRIPTION
- [x] #74
- [x] #78 
- [x] #80 
- [x] #89 
- [x] #87 

---

# Changes

+ Translated DHBW MA AI declaration form to english. #78 @linus-kronenberger 
+ Added support for multiple authors to the DHBW MA AI declaration form. #80 @linus-kronenberger 
+ Changed the behavior of date inputs to accept content instead of date types. For backwards compatibility date types are still supported but deprecated. #74 @F2011
+ Changed `library` to accept a `bibliography` instead of a path string (needed for typst universe release) #89 @F2011 
+ Added `inline-glossary` utility function to print (parts of) the glossary inside the documents body. #87 @habetuz 

# Needed Actions

1. Change usage of `datetime.today()` or `datetime(year: 2026, month: ...)` to `datetime.today().display("[year]-[month]-[day]")` or `"24.12.2026"` for below listed properties.

Future versions will remove `date-format` and drop support for date types in date inputs.

Affected properties:

+ `module-submission-date` (DHBW MA adapter)
+ `submission-date` (DHBW MA/KA and IHK adapters)

2. Pass [`bibliography`](https://typst.app/docs/reference/model/bibliography) to `library` instead of a path string. Future versions will remove the support for passing the path string directly.