### PR TITLE
fix: Wrong numbering in outline with `numbering-show-total`

### DIFF
--- a/template/template/base.typ
+++ b/template/template/base.typ
@@ -384,7 +384,7 @@
         }
       },
       numbering: (..n) => context {
-        if numbering-show-total {
+        if numbering-show-total and not __in-outline.get() {
           numbering("1 / 1", n.at(0), ..counter(page).at(<__content-end>))
         } else {
           numbering("1", n.at(0))


### PR DESCRIPTION
When enabling `numbering-show-total` the total page numbering also occurred in the outline. This PR fixes this to exclude the total page count from the outline numbering.