### PR TITLE
chore: Release notes pipeline

### DIFF
--- a/.github/workflows/checkReleaseNotes.yml
+++ b/.github/workflows/checkReleaseNotes.yml
@@ -1,0 +1,49 @@
+name: Check Release Notes
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to check"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  check_pr_type:
+    name: Determine if release notes are required
+    runs-on: ubuntu-24.04
+    outputs:
+      requires_release_notes: ${{ steps.check.outputs.requires_release_notes }}
+      pr_number: ${{ steps.check.outputs.pr_number }}
+    steps:
+      - name: Determine PR type
+        id: check
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+        run: |
+          echo "pr_number=${PR_NUMBER}" >> "$GITHUB_OUTPUT"
+
+          # `chore:` PRs do not require release notes.
+          # `fix:`, `feat:` and `feat!:` PRs do require release notes.
+          if [[ "$PR_TITLE" =~ ^(fix|feat|feat!)(\(.+\))?:\  ]]; then
+            echo "PR title '${PR_TITLE}' requires release notes."
+            echo "requires_release_notes=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "PR title '${PR_TITLE}' does not require release notes (chore or unknown prefix)."
+            echo "requires_release_notes=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  check_release_notes:
+    name: Check release notes
+    needs: check_pr_type
+    if: needs.check_pr_type.outputs.requires_release_notes == 'true'
+    uses: ./.github/workflows/extractReleaseNotes.yml
+    with:
+      pr_number: ${{ needs.check_pr_type.outputs.pr_number }}
+      fail_if_missing: true

--- a/.github/workflows/checkReleaseNotes.yml
+++ b/.github/workflows/checkReleaseNotes.yml
@@ -14,15 +14,12 @@ permissions:
   pull-requests: read
 
 jobs:
-  check_pr_type:
-    name: Determine if release notes are required
+  check_release_notes:
+    name: Check release notes
     runs-on: ubuntu-24.04
-    outputs:
-      requires_release_notes: ${{ steps.check.outputs.requires_release_notes }}
-      pr_number: ${{ steps.check.outputs.pr_number }}
     steps:
-      - name: Determine PR type
-        id: check
+      - name: Determine if release notes are required
+        id: pr_type
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
@@ -39,11 +36,49 @@ jobs:
             echo "requires_release_notes=false" >> "$GITHUB_OUTPUT"
           fi
 
-  check_release_notes:
-    name: Check release notes
-    needs: check_pr_type
-    if: needs.check_pr_type.outputs.requires_release_notes == 'true'
-    uses: ./.github/workflows/extractReleaseNotes.yml
-    with:
-      pr_number: ${{ needs.check_pr_type.outputs.pr_number }}
-      fail_if_missing: true
+      - name: Fetch PR description
+        if: steps.pr_type.outputs.requires_release_notes == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr_type.outputs.pr_number }}
+        run: |
+          gh pr view "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --json body \
+            --jq '.body' > pr_body.md
+          echo "Fetched PR #${PR_NUMBER} description"
+
+      - name: Check release notes
+        if: steps.pr_type.outputs.requires_release_notes == 'true'
+        run: |
+          # Normalize line endings
+          tr -d '\r' < pr_body.md > pr_body_clean.md
+          mv pr_body_clean.md pr_body.md
+
+          # Find the line number of the last `---` horizontal rule.
+          # A horizontal rule in markdown is a line that contains only `---`
+          # (optionally surrounded by whitespace).
+          last_hr=$(grep -n -E '^[[:space:]]*---[[:space:]]*$' pr_body.md | tail -n 1 | cut -d: -f1)
+
+          if [[ -z "$last_hr" ]]; then
+            echo "::error::No release notes found in PR description."
+            echo "::error::Please add release notes to the PR description after a final '---' horizontal rule."
+            exit 1
+          fi
+
+          # Take everything after the last horizontal rule
+          notes=$(tail -n +$((last_hr + 1)) pr_body.md)
+
+          # Strip leading/trailing blank lines
+          notes=$(printf '%s\n' "$notes" | sed -e '/./,$!d' | tac | sed -e '/./,$!d' | tac)
+
+          if [[ -z "$notes" ]]; then
+            echo "::error::Release notes section is empty."
+            echo "::error::Please add release notes to the PR description after a final '---' horizontal rule."
+            exit 1
+          fi
+
+          echo "Release notes successfully extracted."
+          echo "----- Release notes -----"
+          echo "$notes"
+          echo "-------------------------"

--- a/.github/workflows/checkReleaseNotes.yml
+++ b/.github/workflows/checkReleaseNotes.yml
@@ -14,9 +14,12 @@ permissions:
   pull-requests: read
 
 jobs:
-  check_release_notes:
-    name: Check release notes
+  determine_requirement:
+    name: Determine if release notes are required
     runs-on: ubuntu-24.04
+    outputs:
+      pr_number: ${{ steps.pr_type.outputs.pr_number }}
+      requires_release_notes: ${{ steps.pr_type.outputs.requires_release_notes }}
     steps:
       - name: Determine if release notes are required
         id: pr_type
@@ -36,49 +39,51 @@ jobs:
             echo "requires_release_notes=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Fetch PR description
-        if: steps.pr_type.outputs.requires_release_notes == 'true'
+  extract_release_notes:
+    name: Extract release notes
+    needs: determine_requirement
+    if: needs.determine_requirement.outputs.requires_release_notes == 'true'
+    uses: ./.github/workflows/extractReleaseNotes.yml
+    with:
+      pr_number: ${{ needs.determine_requirement.outputs.pr_number }}
+      fail_if_missing: true
+
+  check_release_notes:
+    name: Check release notes
+    # Run regardless of whether `extract_release_notes` was skipped, succeeded
+    # or failed, so that this job always produces a definitive PR check status.
+    needs:
+      - determine_requirement
+      - extract_release_notes
+    if: ${{ always() && needs.determine_requirement.result == 'success' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Report status
         env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ steps.pr_type.outputs.pr_number }}
+          REQUIRES: ${{ needs.determine_requirement.outputs.requires_release_notes }}
+          EXTRACT_RESULT: ${{ needs.extract_release_notes.result }}
         run: |
-          gh pr view "$PR_NUMBER" \
-            --repo "${{ github.repository }}" \
-            --json body \
-            --jq '.body' > pr_body.md
-          echo "Fetched PR #${PR_NUMBER} description"
-
-      - name: Check release notes
-        if: steps.pr_type.outputs.requires_release_notes == 'true'
-        run: |
-          # Normalize line endings
-          tr -d '\r' < pr_body.md > pr_body_clean.md
-          mv pr_body_clean.md pr_body.md
-
-          # Find the line number of the last `---` horizontal rule.
-          # A horizontal rule in markdown is a line that contains only `---`
-          # (optionally surrounded by whitespace).
-          last_hr=$(grep -n -E '^[[:space:]]*---[[:space:]]*$' pr_body.md | tail -n 1 | cut -d: -f1)
-
-          if [[ -z "$last_hr" ]]; then
-            echo "::error::No release notes found in PR description."
-            echo "::error::Please add release notes to the PR description after a final '---' horizontal rule."
-            exit 1
+          if [[ "$REQUIRES" != "true" ]]; then
+            echo "Release notes are not required for this PR. Check passes."
+            exit 0
           fi
 
-          # Take everything after the last horizontal rule
-          notes=$(tail -n +$((last_hr + 1)) pr_body.md)
-
-          # Strip leading/trailing blank lines
-          notes=$(printf '%s\n' "$notes" | sed -e '/./,$!d' | tac | sed -e '/./,$!d' | tac)
-
-          if [[ -z "$notes" ]]; then
-            echo "::error::Release notes section is empty."
-            echo "::error::Please add release notes to the PR description after a final '---' horizontal rule."
-            exit 1
-          fi
-
-          echo "Release notes successfully extracted."
-          echo "----- Release notes -----"
-          echo "$notes"
-          echo "-------------------------"
+          case "$EXTRACT_RESULT" in
+            success)
+              echo "Release notes successfully extracted from PR description. Check passes."
+              exit 0
+              ;;
+            failure)
+              echo "::error::Release notes are required but were not found in the PR description."
+              echo "::error::Please add release notes to the PR description after a final '---' horizontal rule."
+              exit 1
+              ;;
+            cancelled)
+              echo "::error::Release notes extraction was cancelled."
+              exit 1
+              ;;
+            *)
+              echo "::error::Unexpected extract_release_notes result: '${EXTRACT_RESULT}'."
+              exit 1
+              ;;
+          esac

--- a/.github/workflows/extractReleaseNotes.yml
+++ b/.github/workflows/extractReleaseNotes.yml
@@ -1,0 +1,100 @@
+name: Extract Release Notes
+on:
+  workflow_call:
+    inputs:
+      pr_number:
+        description: "The pull request number to extract release notes from"
+        required: true
+        type: string
+      fail_if_missing:
+        description: "Fail the workflow if no release notes are found"
+        required: false
+        type: boolean
+        default: true
+    outputs:
+      release_notes:
+        description: "The release notes extracted from the PR description"
+        value: ${{ jobs.extract.outputs.release_notes }}
+      has_release_notes:
+        description: "Whether release notes were found"
+        value: ${{ jobs.extract.outputs.has_release_notes }}
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  extract:
+    name: Extract release notes from PR description
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      release_notes: ${{ steps.extract.outputs.release_notes }}
+      has_release_notes: ${{ steps.extract.outputs.has_release_notes }}
+    steps:
+      - name: Fetch PR description
+        id: fetch_pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+        run: |
+          gh pr view "$PR_NUMBER" \
+            --repo "${{ github.repository }}" \
+            --json body \
+            --jq '.body' > pr_body.md
+          echo "Fetched PR #${PR_NUMBER} description"
+      - name: Extract release notes
+        id: extract
+        run: |
+          # Normalize line endings
+          tr -d '\r' < pr_body.md > pr_body_clean.md
+          mv pr_body_clean.md pr_body.md
+
+          # Find the line number of the last `---` horizontal rule.
+          # A horizontal rule in markdown is a line that contains only `---`
+          # (optionally surrounded by whitespace).
+          last_hr=$(grep -n -E '^[[:space:]]*---[[:space:]]*$' pr_body.md | tail -n 1 | cut -d: -f1)
+
+          if [[ -z "$last_hr" ]]; then
+            echo "No horizontal rule (---) found in PR description."
+            echo "has_release_notes=false" >> "$GITHUB_OUTPUT"
+            echo "release_notes<<__EOF__" >> "$GITHUB_OUTPUT"
+            echo "" >> "$GITHUB_OUTPUT"
+            echo "__EOF__" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Take everything after the last horizontal rule
+          notes=$(tail -n +$((last_hr + 1)) pr_body.md)
+
+          # Strip leading/trailing blank lines
+          notes=$(printf '%s\n' "$notes" | sed -e '/./,$!d' | tac | sed -e '/./,$!d' | tac)
+
+          if [[ -z "$notes" ]]; then
+            echo "Release notes section is empty."
+            echo "has_release_notes=false" >> "$GITHUB_OUTPUT"
+            echo "release_notes<<__EOF__" >> "$GITHUB_OUTPUT"
+            echo "" >> "$GITHUB_OUTPUT"
+            echo "__EOF__" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Release notes successfully extracted."
+          echo "----- Release notes -----"
+          echo "$notes"
+          echo "-------------------------"
+
+          echo "has_release_notes=true" >> "$GITHUB_OUTPUT"
+          {
+            echo "release_notes<<__EOF__"
+            echo "$notes"
+            echo "__EOF__"
+          } >> "$GITHUB_OUTPUT"
+      - name: Fail if release notes missing
+        if: inputs.fail_if_missing && steps.extract.outputs.has_release_notes != 'true'
+        run: |
+          echo "::error::No release notes found in PR description."
+          echo "::error::Please add release notes to the PR description after a final '---' horizontal rule."
+          exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,20 +92,10 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Try to find the PR that introduced the current commit on `main`.
-          pr_number=$(gh pr list \
-            --repo "${{ github.repository }}" \
-            --state merged \
-            --search "${{ github.sha }}" \
-            --json number \
+          # Find the PR associated with the current commit on `main`.
+          pr_number=$(gh api \
+            "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
             --jq '.[0].number')
-
-          if [[ -z "$pr_number" || "$pr_number" == "null" ]]; then
-            # Fallback: use the API endpoint that returns PRs associated with a commit.
-            pr_number=$(gh api \
-              "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
-              --jq '.[0].number')
-          fi
 
           if [[ -z "$pr_number" || "$pr_number" == "null" ]]; then
             echo "::error::Could not determine the PR number for commit ${{ github.sha }}."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,10 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: write
+  pull-requests: read
+
 jobs:
   synchronize:
     name: Synchronize files in `template/`
@@ -64,9 +68,68 @@ jobs:
         working-directory: template
         run: |
           git push --force
+  prepare_release:
+    name: Prepare release metadata
+    needs: synchronize
+    runs-on: ubuntu-24.04
+    outputs:
+      hasNextVersion: ${{ steps.version.outputs.hasNextVersion }}
+      version: ${{ steps.version.outputs.version }}
+      pr_number: ${{ steps.find_pr.outputs.pr_number }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+      - name: Get next version
+        uses: thenativeweb/get-next-version@067dc4602577f4f61a51c3f4664552283a228c60
+        id: version
+        with:
+          prefix: "v"
+      - name: Find PR associated with the merge commit
+        id: find_pr
+        if: steps.version.outputs.hasNextVersion == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Try to find the PR that introduced the current commit on `main`.
+          pr_number=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --state merged \
+            --search "${{ github.sha }}" \
+            --json number \
+            --jq '.[0].number')
+
+          if [[ -z "$pr_number" || "$pr_number" == "null" ]]; then
+            # Fallback: use the API endpoint that returns PRs associated with a commit.
+            pr_number=$(gh api \
+              "repos/${{ github.repository }}/commits/${{ github.sha }}/pulls" \
+              --jq '.[0].number')
+          fi
+
+          if [[ -z "$pr_number" || "$pr_number" == "null" ]]; then
+            echo "::error::Could not determine the PR number for commit ${{ github.sha }}."
+            exit 1
+          fi
+
+          echo "Found PR #${pr_number} for commit ${{ github.sha }}"
+          echo "pr_number=${pr_number}" >> "$GITHUB_OUTPUT"
+
+  extract_release_notes:
+    name: Extract release notes
+    needs: prepare_release
+    if: needs.prepare_release.outputs.hasNextVersion == 'true'
+    uses: ./.github/workflows/extractReleaseNotes.yml
+    with:
+      pr_number: ${{ needs.prepare_release.outputs.pr_number }}
+      fail_if_missing: true
+
   release:
     name: Create Release in Dev and Prod
-    needs: synchronize
+    needs:
+      - prepare_release
+      - extract_release_notes
+    if: needs.prepare_release.outputs.hasNextVersion == 'true'
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
@@ -74,13 +137,7 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.BOT_PAT }}
-      - name: Get next version
-        uses: thenativeweb/get-next-version@067dc4602577f4f61a51c3f4664552283a228c60
-        id: version
-        with:
-          prefix: "v"
       - name: Install typst
-        if: steps.version.outputs.hasNextVersion == 'true'
         run: |
           curl -L https://github.com/typst/typst/releases/download/v0.14.2/typst-x86_64-unknown-linux-musl.tar.xz -o typst.tar.xz
           mkdir -p typst_bin
@@ -88,31 +145,29 @@ jobs:
           mv typst_bin/typst-x86_64-unknown-linux-musl/typst typst
           chmod +x typst
       - name: Build template
-        if: steps.version.outputs.hasNextVersion == 'true'
         run: |
           for file in $(ls template/main-*.typ); do
             ./typst compile $file
           done
       - name: Build documentation
-        if: steps.version.outputs.hasNextVersion == 'true'
         run: |
-          ./typst compile documentation.typ --input version=${{ steps.version.outputs.version }}
+          ./typst compile documentation.typ --input version=${{ needs.prepare_release.outputs.version }}
       - name: Release dev repo
-        if: steps.version.outputs.hasNextVersion == 'true'
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           token: ${{ secrets.BOT_PAT }}
           files: |
             template/main-*.pdf
             documentation.pdf
-          tag_name: ${{ steps.version.outputs.version }}
+          tag_name: ${{ needs.prepare_release.outputs.version }}
+          body: ${{ needs.extract_release_notes.outputs.release_notes }}
       - name: Release prod repo
-        if: steps.version.outputs.hasNextVersion == 'true'
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           token: ${{ secrets.BOT_PAT }}
           files: |
             template/main-*.pdf
             documentation.pdf
-          tag_name: ${{ steps.version.outputs.version }}
+          tag_name: ${{ needs.prepare_release.outputs.version }}
           repository: dhbw-typst/oderso-template
+          body: ${{ needs.extract_release_notes.outputs.release_notes }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,3 +39,20 @@ These prefixes are used by our release pipeline to determine the next version bu
 - `feat!`: (_Major bump_) Should be used for major changes to the look of the template or when making changes that are not backwards compatible.
 
 Add the correct prefix to your PR title (e.g., `fix: <PR title>`). If you are unsure, let us know in your PR description.
+
+### Release Notes
+
+For non-`chore` PRs (i.e. PRs prefixed with `fix:`, `feat:` or `feat!:`), the PR description must contain release notes.
+The release notes are everything that follows the **last** horizontal rule (`---`) in the PR description and will be used as the body of the GitHub release that is created when the PR is merged.
+
+Example PR description:
+
+```markdown
+Some information about the PR
+
+---
+# Changes
+
+- Added a new function
+- Removed property `x` of `some-function`
+```


### PR DESCRIPTION
This PR introduces release notes fetching from the PR description as described in #46. The last `hl` will be used to determine the start of the release notes. Besides modifying the release pipeline a new check is added to prevent PRs from merging if they are missing release notes.

This behavior is explained in the contribution guide.

The pipeline was created with the help of dear @claude but reviewed me and verified in my fork of this repo. See https://github.com/habetuz/oderso-template-dev and the last commit for the action in action.