### PR TITLE
chore: Make dhbw-ma Owner of AI Declaration Form

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,6 +8,7 @@ template/main-dhbw-ka.typ @dhbw-typst/dhbw-ka
 
 ## DHBW Mannheim
 template/template/dhbw-ma.typ @dhbw-typst/dhbw-ma
+template/template/assets/ai-declaration-form_dhbw-ma.typ
 template/main-dhbw-ma.typ @dhbw-typst/dhbw-ma
 
 ## IHK

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,7 +8,7 @@ template/main-dhbw-ka.typ @dhbw-typst/dhbw-ka
 
 ## DHBW Mannheim
 template/template/dhbw-ma.typ @dhbw-typst/dhbw-ma
-template/template/assets/ai-declaration-form_dhbw-ma.typ
+template/template/assets/ai-declaration-form_dhbw-ma.typ @dhbw-typst/dhbw-ma
 template/main-dhbw-ma.typ @dhbw-typst/dhbw-ma
 
 ## IHK


### PR DESCRIPTION
`ai-declaration-form_dhbw-ma.typ` should be owned by dhbw-ma