### PR TITLE
chore: Add branch selector to release notes check pipeline

### DIFF
--- a/.github/workflows/checkReleaseNotes.yml
+++ b/.github/workflows/checkReleaseNotes.yml
@@ -2,6 +2,8 @@ name: Check Release Notes
 on:
   pull_request:
     types: [opened, edited, synchronize, reopened]
+    branches:
+      - 'main'
   workflow_dispatch:
     inputs:
       pr_number:


### PR DESCRIPTION
This PR adds a branch selector to the release notes check pipeline to only run the check on PRs targeting `main`.

PRs targeting branches other than `main` do not need release notes, as they'll never trigger a release.