### PR TITLE
feat: Add `inline-glossary` utility function

### DIFF
--- a/template/chapters/advanced_elements.typ
+++ b/template/chapters/advanced_elements.typ
@@ -102,7 +102,7 @@ You can reference labeled equations like other figures. @math-figure shows the s
 
 == Inline Glossary
 
-If you want to include parts of your glossary in your documents content this is possible using the `inline-glossary` function. This is useful if you need word definitions directly in a chapter let the reader explicitly read those definitions. The `group` parameter can be used to only show parts of the glossary. In the following example the _Dependency_ group of the example glossary defined in `glossary.typ` is shown. The _Dependency_ group contains definitions for @glossarium, @drafting, @codly, @hydra and @linguify, which are the packages used by this template.
+If you want to include parts of your glossary in your documents content this is possible using the `inline-glossary` function. This is useful if you need word definitions directly in a chapter and want the reader to explicitly read those definitions. The `group` parameter can be used to only show parts of the glossary. In the following example the _Dependency_ group of the example glossary defined in `glossary.typ` is shown. The _Dependency_ group contains definitions for @glossarium, @drafting, @codly, @hydra and @linguify, which are the packages used by this template.
 
 #typst-preview(
   "Inline Glossary Showing the Templates Dependencies",

--- a/template/chapters/advanced_elements.typ
+++ b/template/chapters/advanced_elements.typ
@@ -102,7 +102,7 @@ You can reference labeled equations like other figures. @math-figure shows the s
 
 == Inline Glossary
 
-If you want to include parts of your glossary in your documents content this is possible using the `inline-glossary` function. This is useful if you need word definitions directly in a chapter let the reader explicitly read those definitions. The `group` parameter can be used to only show parts of the glossary. The following example shows the _Dependency_ group of the provided example glossary in `glossary.typ` containing definition for @glossarium, @drafting, @codly, @hydra and @linguify.
+If you want to include parts of your glossary in your documents content this is possible using the `inline-glossary` function. This is useful if you need word definitions directly in a chapter let the reader explicitly read those definitions. The `group` parameter can be used to only show parts of the glossary. In the following example the _Dependency_ group of the example glossary defined in `glossary.typ` is shown. The _Dependency_ group contains definitions for @glossarium, @drafting, @codly, @hydra and @linguify, which are the packages used by this template.
 
 #typst-preview(
   "Inline Glossary Showing the Templates Dependencies",

--- a/template/chapters/advanced_elements.typ
+++ b/template/chapters/advanced_elements.typ
@@ -100,6 +100,19 @@ You can reference labeled equations like other figures. @math-figure shows the s
 ]",
 )
 
+== Inline Glossary
+
+If you want to include parts of your glossary in your documents content this is possible using the `inline-glossary` function. This is useful if you need word definitions directly in a chapter let the reader explicitly read those definitions. The `group` parameter can be used to only show parts of the glossary. The following example shows the _Dependency_ group of the provided example glossary in `glossary.typ` containing definition for @glossarium, @drafting, @codly, @hydra and @linguify.
+
+#typst-preview(
+  "Inline Glossary Showing the Templates Dependencies",
+  "#import \"../template/lib.typ\": inline-glossary
+#import \"../glossary.typ\": glossary
+
+#inline-glossary(glossary, (\"Dependencies\",), show-all: true)"
+)
+
+
 == Notes
 
 #import "@preview/drafting:0.2.2": inline-note, margin-note

--- a/template/chapters/advanced_elements.typ
+++ b/template/chapters/advanced_elements.typ
@@ -109,7 +109,7 @@ If you want to include parts of your glossary in your documents content this is 
   "#import \"../template/lib.typ\": inline-glossary
 #import \"../glossary.typ\": glossary
 
-#inline-glossary(glossary, (\"Dependencies\",), show-all: true)"
+#inline-glossary(glossary, (\"Dependencies\",), show-all: true)",
 )
 
 

--- a/template/glossary.typ
+++ b/template/glossary.typ
@@ -1,0 +1,59 @@
+// Specify abbreviations here.
+// The key is used to reference the acronym.
+// The short form is used every time and the long form is used
+// additionally the first time you reference the acronym.
+#let abbreviations = (
+  (key: "NN", short: "NN", long: "Neural Network"),
+  (key: "SG", short: "SG", long: "Singular"),
+)
+
+// Specify glossary terms here for term definitions (not abbreviations).
+// The key is used to reference the term.
+// The long form is the term and the short form is the abbreviation (only if you need it).
+// The description is used for the detailed explanation of the term.
+// Set to empty array () if you don't need a glossary.
+#let glossary = (
+  (
+    key: "typ",
+    short: "Typst",
+    description: "Typst is a new markup-based typesetting system that is designed to be as powerful as LaTeX while being much easier to learn and use.",
+  ),
+  (
+    key: "glossarium",
+    short: "Glossarium",
+    description: [Glossarium is a simple, easily customizable typst glossary inspired by the #link("https://www.ctan.org/pkg/glossaries", "LaTeX glossaries package")],
+    group: "Dependencies",
+  ),
+  (
+    key: "drafting",
+    short: "Drafting",
+    description: [
+      The Drafting package contains functions for content positioning and margin comments/notes.
+    ],
+    group: "Dependencies",
+  ),
+  (
+    key: "codly",
+    short: "Codly",
+    description: [
+      Codly provides styled code blocks with many features like smart indentation, line numbering, highlighting, etc.
+    ],
+    group: "Dependencies",
+  ),
+  (
+    key: "hydra",
+    short: "Hydra",
+    description: [
+      Hydra is a Typst package allowing easily displaying the current heading in the page header.
+    ],
+    group: "Dependencies",
+  ),
+  (
+    key: "linguify",
+    short: "Linguify",
+    description: [
+      Linguify brings #link("https://projectfluent.org/fluent/guide/", "fluent") support to typst, enabling easy i18n.
+    ],
+    group: "Dependencies",
+  )
+)

--- a/template/glossary.typ
+++ b/template/glossary.typ
@@ -55,5 +55,5 @@
       Linguify brings #link("https://projectfluent.org/fluent/guide/", "fluent") support to typst, enabling easy i18n.
     ],
     group: "Dependencies",
-  )
+  ),
 )

--- a/template/main-dhbw-ka.typ
+++ b/template/main-dhbw-ka.typ
@@ -1,5 +1,6 @@
 // LTeX: enabled=false
 #import "template/lib.typ": caption-with-source, dhbw-ka-adapter
+#import "glossary.typ": glossary, abbreviations
 
 #show: dhbw-ka-adapter.with(
   lang: "en",
@@ -107,28 +108,8 @@
   // * for `.yaml` files see: [hayagriva](https://github.com/typst/hayagriva)
   library: "refs.bib",
 
-  // Specify abbreviations here.
-  // The key is used to reference the acronym.
-  // The short form is used every time and the long form is used
-  // additionally the first time you reference the acronym.
-  abbreviations: (
-    (key: "NN", short: "NN", long: "Neural Network"),
-    (key: "SG", short: "SG", long: "Singular"),
-  ),
-
-  // Specify glossary terms here for term definitions (not abbreviations).
-  // The key is used to reference the term.
-  // The long form is the term and the short form is the abbreviation (only if you need it).
-  // The description is used for the detailed explanation of the term.
-  // Set to empty array () if you don't need a glossary.
-  glossary: (
-    (
-      key: "typ",
-      short: none,
-      long: "Typst",
-      description: "Typst is a new markup-based typesetting system that is designed to be as powerful as LaTeX while being much easier to learn and use.",
-    ),
-  ),
+  abbreviations: abbreviations,
+  glossary: glossary,
 )
 
 // You can now start writing :)

--- a/template/main-dhbw-ka.typ
+++ b/template/main-dhbw-ka.typ
@@ -1,6 +1,6 @@
 // LTeX: enabled=false
 #import "template/lib.typ": caption-with-source, dhbw-ka-adapter
-#import "glossary.typ": glossary, abbreviations
+#import "glossary.typ": abbreviations, glossary
 
 #show: dhbw-ka-adapter.with(
   lang: "en",

--- a/template/main-dhbw-ma.typ
+++ b/template/main-dhbw-ma.typ
@@ -1,5 +1,6 @@
 // LTeX: enabled=false
 #import "template/lib.typ": caption-with-source, dhbw-ma-adapter
+#import "glossary.typ": abbreviations, glossary
 
 #show: dhbw-ma-adapter.with(
   lang: "en",

--- a/template/main-dhbw-ma.typ
+++ b/template/main-dhbw-ma.typ
@@ -123,28 +123,8 @@
   // * for `.yaml` files see: [hayagriva](https://github.com/typst/hayagriva)
   library: "refs.bib",
 
-  // Specify abbreviations here.
-  // The key is used to reference the acronym.
-  // The short form is used every time and the long form is used
-  // additionally the first time you reference the acronym.
-  abbreviations: (
-    (key: "NN", short: "NN", long: "Neural Network"),
-    (key: "SG", short: "SG", long: "Singular"),
-  ),
-
-  // Specify glossary terms here for term definitions (not abbreviations).
-  // The key is used to reference the term.
-  // The long form is the term and the short form is the abbreviation (only if you need it).
-  // The description is used for the detailed explanation of the term.
-  // Set to empty array () if you don't need a glossary.
-  glossary: (
-    (
-      key: "typ",
-      short: none,
-      long: "Typst",
-      description: "Typst is a new markup-based typesetting system that is designed to be as powerful as LaTeX while being much easier to learn and use.",
-    ),
-  ),
+  abbreviations: abbreviations,
+  glossary: glossary,
 )
 
 // You can now start writing :)

--- a/template/main-ihk.typ
+++ b/template/main-ihk.typ
@@ -1,5 +1,6 @@
 // LTeX: enabled=false
 #import "template/lib.typ": caption-with-source, ihk-adapter
+#import "glossary.typ": abbreviations, glossary
 
 #show: ihk-adapter.with(
   lang: "de",

--- a/template/main-ihk.typ
+++ b/template/main-ihk.typ
@@ -57,28 +57,8 @@
   // Path/s to references - .bib files
   library: "refs.bib",
 
-  // Specify abbreviations here.
-  // The key is used to reference the acronym.
-  // The short form is used every time and the long form is used
-  // additionally the first time you reference the acronym.
-  abbreviations: (
-    (key: "NN", short: "NN", long: "Neural Network"),
-    (key: "SG", short: "SG", long: "Singular"),
-  ),
-
-  // Specify glossary terms here for term definitions (not abbreviations).
-  // The key is used to reference the term.
-  // The long form is the term and the short form is the abbreviation (only if you need it).
-  // The description is used for the detailed explanation of the term.
-  // Set to empty array () if you don't need a glossary.
-  glossary: (
-    (
-      key: "typ",
-      short: none,
-      long: "Typst",
-      description: "Typst is a new markup-based typesetting system that is designed to be as powerful as LaTeX while being much easier to learn and use.",
-    ),
-  ),
+  abbreviations: abbreviations,
+  glossary: glossary,
 )
 
 // You can now start writing :)

--- a/template/template/lib.typ
+++ b/template/template/lib.typ
@@ -8,5 +8,6 @@
 #import "utils.typ": (
   caption-with-source, styled-table, table-hline-spaced, tablefigure,
   tablefigure-raw,
+  inline-glossary,
 )
 #import "base.typ": project

--- a/template/template/lib.typ
+++ b/template/template/lib.typ
@@ -6,8 +6,7 @@
 #import "dhbw-ma.typ": dhbw-ma-adapter
 #import "ihk.typ": ihk-adapter
 #import "utils.typ": (
-  caption-with-source, styled-table, table-hline-spaced, tablefigure,
-  tablefigure-raw,
-  inline-glossary,
+  caption-with-source, inline-glossary, styled-table, table-hline-spaced,
+  tablefigure, tablefigure-raw,
 )
 #import "base.typ": project

--- a/template/template/utils.typ
+++ b/template/template/utils.typ
@@ -1,6 +1,7 @@
 // LTeX: enabled=false
 
 #import "@preview/linguify:0.5.0": linguify-raw
+#import "@preview/glossarium:0.5.10": print-glossary
 
 /// Internal state to track whether we are currently rendering an outline.
 /// -> state
@@ -231,4 +232,60 @@
 
 #let __linguify-content(..args) = {
   context eval(linguify-raw(..args), mode: "markup")
+}
+
+/// Displays a glossary without interfering with the glossary shown at the end of the document.
+///
+/// Usefull when wanting to display part of a glossary in the document content.
+///
+/// Wraps `print-glossary` by `glossarium`. See the #link("https://typst.app/universe/package/glossarium/", "glossarium documentation") for more information.
+///
+/// -> content
+#let inline-glossary(
+  /// The list of entries -> array
+  entry-list,
+  /// The list of groups to display (only included groups will be shown the rest will be hidden) -> array
+  groups,
+  /// Whether to show group headings or not -> bool
+  display-headings: false,
+  /// Additional arguments passed to `print-glossary` -> arguments
+  ..args) = {
+
+  let custom-print-reference(
+    entry,
+    show-all: false,
+    disable-back-references: false,
+    deduplicate-back-references: false,
+    minimum-refs: 1,
+    description-separator: ": ",
+    shorthands: none,
+    user-print-gloss: none,
+    user-print-title: none,
+    user-print-description: none,
+    user-print-back-references: none,
+  ) = {
+    user-print-gloss(
+      entry,
+      show-all: show-all,
+      disable-back-references: true,
+      deduplicate-back-references: deduplicate-back-references,
+      minimum-refs: minimum-refs,
+      description-separator: description-separator,
+      user-print-title: user-print-title,
+      user-print-description: user-print-description,
+      user-print-back-references: user-print-back-references,
+    )
+  }
+
+  let args-cp = args.named()
+  if not display-headings {
+    args-cp.insert("user-print-group-heading", (..args) => {})
+  }
+
+  print-glossary(
+    entry-list,
+    groups: groups,
+    user-print-reference: custom-print-reference,
+    ..args-cp,
+  )
 }

--- a/template/template/utils.typ
+++ b/template/template/utils.typ
@@ -238,7 +238,7 @@
 ///
 /// Usefull when wanting to display part of a glossary in the document content.
 ///
-/// Wraps `print-glossary` by `glossarium`. See the #link("https://typst.app/universe/package/glossarium/", "glossarium documentation") for more information.
+/// Wraps `print-glossary` by `glossarium`. See the #link("https://typst.app/universe/package/glossarium/")[glossarium documentation] for more information.
 ///
 /// -> content
 #let inline-glossary(

--- a/template/template/utils.typ
+++ b/template/template/utils.typ
@@ -249,8 +249,8 @@
   /// Whether to show group headings or not -> bool
   display-headings: false,
   /// Additional arguments passed to `print-glossary` -> arguments
-  ..args) = {
-
+  ..args,
+) = {
   let custom-print-reference(
     entry,
     show-all: false,


### PR DESCRIPTION
This PR adds a `inline-glossary` utility to display (parts of) the glossary inside the document content.

<img width="978" height="967" alt="Screenshot 2026-06-02 at 16 57 44" src="https://github.com/user-attachments/assets/1d663647-20de-4137-9747-ec3d4b82780c" />
