### PR TITLE
feat: Move bibliography call into main functions

### DIFF
--- a/template/main-dhbw-ka.typ
+++ b/template/main-dhbw-ka.typ
@@ -103,8 +103,7 @@
     ), // appendix from file
   ),
 
-  // Path to reference - either .yaml or .bib file
-  // * for `.yaml` files see: [hayagriva](https://github.com/typst/hayagriva)
+  // Bibliography
   library: bibliography("refs.bib"),
 
   // Specify abbreviations here.

--- a/template/main-dhbw-ka.typ
+++ b/template/main-dhbw-ka.typ
@@ -105,7 +105,7 @@
 
   // Path to reference - either .yaml or .bib file
   // * for `.yaml` files see: [hayagriva](https://github.com/typst/hayagriva)
-  library: "refs.bib",
+  library: bibliography("refs.bib"),
 
   // Specify abbreviations here.
   // The key is used to reference the acronym.

--- a/template/main-dhbw-ma.typ
+++ b/template/main-dhbw-ma.typ
@@ -120,7 +120,7 @@
 
   // Path to reference - either .yaml or .bib file
   // * for `.yaml` files see: [hayagriva](https://github.com/typst/hayagriva)
-  library: "refs.bib",
+  library: bibliography("refs.bib"),
 
   // Specify abbreviations here.
   // The key is used to reference the acronym.

--- a/template/main-dhbw-ma.typ
+++ b/template/main-dhbw-ma.typ
@@ -119,8 +119,7 @@
     ), // appendix from file
   ),
 
-  // Path to reference - either .yaml or .bib file
-  // * for `.yaml` files see: [hayagriva](https://github.com/typst/hayagriva)
+  // Bibliography
   library: bibliography("refs.bib"),
 
   // Specify abbreviations here.

--- a/template/main-ihk.typ
+++ b/template/main-ihk.typ
@@ -54,7 +54,7 @@
     ), // appendix from file
   ),
 
-  // Path/s to references - .bib files
+  // Bibliography
   library: bibliography("refs.bib"),
 
   // Specify abbreviations here.

--- a/template/main-ihk.typ
+++ b/template/main-ihk.typ
@@ -55,7 +55,7 @@
   ),
 
   // Path/s to references - .bib files
-  library: "refs.bib",
+  library: bibliography("refs.bib"),
 
   // Specify abbreviations here.
   // The key is used to reference the acronym.

--- a/template/template/base.typ
+++ b/template/template/base.typ
@@ -415,8 +415,8 @@
   set page(numbering: "a", footer: auto)
   counter(page).update(1)
 
-  // TODO: remove with 3.0.0
   // This is just for supporting the old method of usage, but it is deprecated
+  // TODO: with typst 0.15.0 and the introduction of path types, the bibliograhy call should be moved back into base.typ again
   if type(library) == str {
     bibliography(
       "../" + library,

--- a/template/template/base.typ
+++ b/template/template/base.typ
@@ -420,7 +420,6 @@
   if type(library) == str {
     bibliography(
       "../" + library,
-      title: __linguify-content("bibliography"),
     )
   } else {
     library

--- a/template/template/base.typ
+++ b/template/template/base.typ
@@ -148,6 +148,8 @@
   // load linguify
   set-database(eval(load-ftl-data("l10n", ("en", "de"))))
 
+  set bibliography(title: __linguify-content("bibliography"))
+
   // page setup
   set document(title: title-long)
   set page(paper: "a4", margin: (rest: 2.5cm))
@@ -408,10 +410,16 @@
   set page(numbering: "a", footer: auto)
   counter(page).update(1)
 
-  bibliography(
-    "../" + library,
-    title: __linguify-content("bibliography"),
-  )
+  // TODO: remove with 3.0.0
+  // This is just for supporting the old method of usage, but it is deprecated
+  if type(library) == str {
+    bibliography(
+      "../" + library,
+      title: __linguify-content("bibliography"),
+    )
+  } else {
+    library
+  }
 
   // lists and declarations (between content and appendix)
   {

--- a/template/template/base.typ
+++ b/template/template/base.typ
@@ -416,7 +416,7 @@
   counter(page).update(1)
 
   // This is just for supporting the old method of usage, but it is deprecated
-  // TODO: with typst 0.15.0 and the introduction of path types, the bibliograhy call should be moved back into base.typ again
+  // TODO: probably rework with Typst 0.15.0
   if type(library) == str {
     bibliography(
       "../" + library,


### PR DESCRIPTION
As typst is currently only supporting relative paths, we cannot move the template into any directory with the current logic.
That's why we need to move the bibliography function into the main files as they will always live in the root directory.

This becomes obsolete with the release of typst 0.15.0