### PR TITLE
chore: Replace curl with setup-typst action

### DIFF
--- a/.github/workflows/codeAnalysis.yml
+++ b/.github/workflows/codeAnalysis.yml
@@ -52,16 +52,13 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
       - name: Install typst
-        run: |
-          curl -L https://github.com/typst/typst/releases/download/v0.14.2/typst-x86_64-unknown-linux-musl.tar.xz -o typst.tar.xz
-          mkdir -p typst_bin
-          tar -xf typst.tar.xz -C typst_bin
-          mv typst_bin/typst-x86_64-unknown-linux-musl/typst typst
-          chmod +x typst
+        uses: typst-community/setup-typst@63ac138db421d586de61f7f5ac3bcef6a2e6c78c # v5.1.0
+        with:
+          typst-version: 0.14.2
       - name: Typst version
-        run: ./typst --version
+        run: typst --version
       - name: Build template
-        run: ./typst compile ${{ matrix.path }}
+        run: typst compile ${{ matrix.path }}
 
   check_build_results:
     name: Check Build Result
@@ -87,17 +84,14 @@ jobs:
         with:
           path: new
       - name: Install typst
-        run: |
-          curl -L https://github.com/typst/typst/releases/download/v0.14.2/typst-x86_64-unknown-linux-musl.tar.xz -o typst.tar.xz
-          mkdir -p typst_bin
-          tar -xf typst.tar.xz -C typst_bin
-          mv typst_bin/typst-x86_64-unknown-linux-musl/typst typst
-          chmod +x typst
+        uses: typst-community/setup-typst@63ac138db421d586de61f7f5ac3bcef6a2e6c78c # v5.1.0
+        with:
+          typst-version: 0.14.2
       - name: Typst version
-        run: ./typst --version
+        run: typst --version
       - name: Build PDF on PR branch
         run: |
-          ./typst compile new/${{ matrix.path }} new.pdf
+          typst compile new/${{ matrix.path }} new.pdf
       - name: Checkout base branch
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
@@ -105,7 +99,7 @@ jobs:
           path: old
       - name: Build PDF on main branch
         run: |
-          ./typst compile old/${{ matrix.path }} old.pdf
+          typst compile old/${{ matrix.path }} old.pdf
       - name: Compare PDFs
         id: diff_check
         uses: nowsprinting/diff-pdf-action@21193e71055e9cd98ae8704bf95590e50fb0d3c3 # v1.2.3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,20 +128,19 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.BOT_PAT }}
       - name: Install typst
-        run: |
-          curl -L https://github.com/typst/typst/releases/download/v0.14.2/typst-x86_64-unknown-linux-musl.tar.xz -o typst.tar.xz
-          mkdir -p typst_bin
-          tar -xf typst.tar.xz -C typst_bin
-          mv typst_bin/typst-x86_64-unknown-linux-musl/typst typst
-          chmod +x typst
+        uses: typst-community/setup-typst@63ac138db421d586de61f7f5ac3bcef6a2e6c78c # v5.1.0
+        with:
+          typst-version: 0.14.2
+      - name: Typst version
+        run: typst --version
       - name: Build template
         run: |
           for file in $(ls template/main-*.typ); do
-            ./typst compile $file
+            typst compile $file
           done
       - name: Build documentation
         run: |
-          ./typst compile documentation.typ --input version=${{ needs.prepare_release.outputs.version }}
+          typst compile documentation.typ --input version=${{ needs.prepare_release.outputs.version }}
       - name: Release dev repo
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["helpers:pinGitHubActionDigests"],
+  "extends": [
+    "helpers:pinGitHubActionDigests"
+  ],
   "customManagers": [
     {
       "customType": "regex",

--- a/renovate.json
+++ b/renovate.json
@@ -18,6 +18,20 @@
       "versioningTemplate": "semver",
       "datasourceTemplate": "github-releases",
       "packageNameTemplate": "{{owner}}/{{packageName}}"
+    },
+    {
+      "customType": "regex",
+      "description": "Typst version with setup-typst action",
+      "managerFilePatterns": [
+        "/\\.github/workflows/.*\\.yml$/"
+      ],
+      "matchStrings": [
+        "uses: typst-community\\/setup-typst\\@[0-9a-f]{40} \\# v\\d+\\.\\d+\\.\\d+\\n\\s*with:\\n\\s*typst-version: (?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "depNameTemplate": "typst",
+      "versioningTemplate": "semver",
+      "datasourceTemplate": "github-releases",
+      "packageNameTemplate": "typst/typst"
     }
   ]
 }


### PR DESCRIPTION
Although, I originally voted against it, after some issues with the curl approach, I see no advantages in this approach anymore. There were several failures of action runs (I don't know if the new action will really fix this, but let's see).

The biggest caveat of the curl approach is that the workflow files are less maintainable (less clean) with bash code in them, so the use of an action makes it more maintainable, I hope :)

EDIT: The action could not fix GitHub's availability problems xD