### PR TITLE
fix: `glossarium`-abbreviations in headings not working

### DIFF
--- a/template/template/base.typ
+++ b/template/template/base.typ
@@ -322,6 +322,16 @@
   counter(page).update(1)
   set page(numbering: "I")
 
+  // register abbreviations before content so references resolve
+  if abbreviations.len() > 0 {
+    register-glossary(abbreviations)
+  }
+
+  // register glossary entries before content so references resolve
+  if glossary.len() > 0 {
+    register-glossary(glossary)
+  }
+
   // abstracts
   for a in abstracts {
     let (abstract-lang, abstract-lang-long, abstract-body) = a
@@ -362,16 +372,6 @@
         <__appendix-start>,
       ),
     )
-  }
-
-  // register abbreviations before content so references resolve
-  if abbreviations.len() > 0 {
-    register-glossary(abbreviations)
-  }
-
-  // register glossary entries before content so references resolve
-  if glossary.len() > 0 {
-    register-glossary(glossary)
   }
 
   {


### PR DESCRIPTION
If a `glossarium` abbreviation is used in a heading, this breaks our current setup:
```typ
= @AI 
```
The above example leads to an error in our current setup as when the outline gets created, the glossarium entries are not registered, yet.

---

# Changes

- Fix glossary references not working in headings and abstracts #97 @F2011 