### PR TITLE
fix: total page numbering

### DIFF
--- a/template/template/base.typ
+++ b/template/template/base.typ
@@ -406,14 +406,18 @@
           line(length: 100%, stroke: (paint: gray))
         }
       },
-      numbering: (..n) => context {
-        if numbering-show-total and not __in-outline.get() {
-          numbering("1 / 1", n.at(0), ..counter(page).at(<__content-end>))
+      numbering: "1",
+      footer: context align(center, {
+        if numbering-show-total {
+          numbering(
+            "1 / 1",
+            counter(page).get().at(0),
+            ..counter(page).at(<__content-end>),
+          )
         } else {
-          numbering("1", n.at(0))
+          numbering("1", counter(page).get().at(0))
         }
-      },
-      footer: auto,
+      }),
     )
     show heading.where(level: 1): it => {
       pagebreak(weak: true)


### PR DESCRIPTION
For some reason mid-outline the numbering in the table contents changes from simple numbering ("1") to total page numbering ("1/1"). This PR fixes this by always using simple numbering ("1") and instead styling the content page footer depending on the `numbering-show-total` parameter.

Tested in my BA